### PR TITLE
Peptide and source assignment tables + protein tree viewer in Arborist frontend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -415,7 +415,7 @@ save: | build/arborist/nanobot.db
 	valve-export data $| build/arborist/ $$(grep build src/arborist/table.tsv | cut -f1 | tr '\n' ' ')
 	python3 src/organism/sort_organism_core.py src/organism/organism_core.tsv
 
-DROPTABLES := proteomes active_species organism_core organism_tree_tsv prefix column datatype table message history
+DROPTABLES := peptide_assignments source_assignments proteomes active_species organism_core organism_tree_tsv prefix column datatype table message history
 .PHONY: reload
 reload: src/organism/check_organism_core.py | build/arborist/nanobot.db
 	sqlite3 $| $(foreach DT,$(DROPTABLES),"DROP VIEW IF EXISTS '$(DT)_text_view'" "DROP VIEW IF EXISTS '$(DT)_view'" "DROP TABLE IF EXISTS '$(DT)_conflict'" "DROP TABLE IF EXISTS '$(DT)'")

--- a/src/arborist/column.tsv
+++ b/src/arborist/column.tsv
@@ -56,8 +56,8 @@ proteome	Proteome Label		empty	label	unique
 proteome	Proteome Link		empty	label	unique	
 proteome	Updated		empty	label		
 peptide_assignments	Species Taxon ID			tax_id	primary	
-peptide_assignments	Species Name			label	unique	
-peptide_assignments	Accession			label	unique	
+peptide_assignments	Species Name			label		
+peptide_assignments	Accession			label		
 peptide_assignments	Sequence			label		
 peptide_assignments	Source Name			label		
 peptide_assignments	Organism ID			tax_id		
@@ -66,8 +66,8 @@ peptide_assignments	Assigned Protein ID		empty	label
 peptide_assignments	Assigned Protein Name		empty	label		
 peptide_assignments	ARC Assignment		empty	label		
 source_assignments	Species Taxon ID			tax_id	primary	
-source_assignments	Species Name			label	unique	
-source_assignments	Accession			label	unique	
+source_assignments	Species Name			label		
+source_assignments	Accession			label		
 source_assignments	Name			label		
 source_assignments	Organism ID			tax_id		
 source_assignments	Length			natural_number		

--- a/src/arborist/column.tsv
+++ b/src/arborist/column.tsv
@@ -55,3 +55,24 @@ proteome	Proteome Organism ID		empty	label	unique
 proteome	Proteome Label		empty	label	unique	
 proteome	Proteome Link		empty	label	unique	
 proteome	Updated		empty	label		
+peptide_assignments	Species Taxon ID
+peptide_assignments	Species Name
+peptide_assignments	Accession
+peptide_assignments	Sequence
+peptide_assignments	Source Name
+peptide_assignments	Organism ID
+peptide_assignments	Assigned Gene
+peptide_assignments	Assigned Protein ID
+peptide_assignments	Assigned Protein Name
+peptide_assignments	ARC Assignment
+source_assignments	Species Taxon ID
+source_assignments	Species Name
+source_assignments	Accession
+source_assignments	Name
+source_assignments	Organism ID
+source_assignments	Length
+source_assignments	Assigned Gene
+source_assignments	Assigned Protein ID
+source_assignments	Assigned Protein Name
+source_assignments	Assignment Score
+source_assignments	ARC Assignment

--- a/src/arborist/column.tsv
+++ b/src/arborist/column.tsv
@@ -55,24 +55,24 @@ proteome	Proteome Organism ID		empty	label	unique
 proteome	Proteome Label		empty	label	unique	
 proteome	Proteome Link		empty	label	unique	
 proteome	Updated		empty	label		
-peptide_assignments	Species Taxon ID
-peptide_assignments	Species Name
-peptide_assignments	Accession
-peptide_assignments	Sequence
-peptide_assignments	Source Name
-peptide_assignments	Organism ID
-peptide_assignments	Assigned Gene
-peptide_assignments	Assigned Protein ID
-peptide_assignments	Assigned Protein Name
-peptide_assignments	ARC Assignment
-source_assignments	Species Taxon ID
-source_assignments	Species Name
-source_assignments	Accession
-source_assignments	Name
-source_assignments	Organism ID
-source_assignments	Length
-source_assignments	Assigned Gene
-source_assignments	Assigned Protein ID
-source_assignments	Assigned Protein Name
-source_assignments	Assignment Score
-source_assignments	ARC Assignment
+peptide_assignments	Species Taxon ID			tax_id	primary	
+peptide_assignments	Species Name			label	unique	
+peptide_assignments	Accession			label	unique	
+peptide_assignments	Sequence			label		
+peptide_assignments	Source Name			label		
+peptide_assignments	Organism ID			tax_id		
+peptide_assignments	Assigned Gene		empty	label		
+peptide_assignments	Assigned Protein ID		empty	label		
+peptide_assignments	Assigned Protein Name		empty	label		
+peptide_assignments	ARC Assignment		empty	label		
+source_assignments	Species Taxon ID			tax_id	primary	
+source_assignments	Species Name			label	unique	
+source_assignments	Accession			label	unique	
+source_assignments	Name			label		
+source_assignments	Organism ID			tax_id		
+source_assignments	Length			natural_number		
+source_assignments	Assigned Gene		empty	label		
+source_assignments	Assigned Protein ID		empty	label		
+source_assignments	Assigned Protein Name		empty	label		
+source_assignments	Assignment Score		empty	natural_number		
+source_assignments	ARC Assignment		empty	label		

--- a/src/arborist/table.tsv
+++ b/src/arborist/table.tsv
@@ -7,3 +7,5 @@ organism_core	../../src/organism/organism_core.tsv		the core structure of the or
 organism_tree_tsv	organism-tree.tsv		the taxa used by IEDB, with their assigned species and upper nodes
 active_species	active-species.tsv		the species for which the IEDB attempts to find proteomes
 proteome	proteome.tsv		the selected proteomes for the active species
+peptide_assignments	all-peptide-assignments.tsv		the proteins and genes assigned to each peptide
+source_assignments	all-source-assignments.tsv		the proteins and genes assigned to each source

--- a/src/util/serve.py
+++ b/src/util/serve.py
@@ -54,6 +54,9 @@ def index():
         'Subspecies Tree': 'subspecies_tree/NCBITaxon:1',
         'Active Species': 'active_species',
         'Proteome': 'proteome',
+        'Peptide Assignments': 'peptide_assignments',
+        'Source Assignments': 'source_assignments',
+        'Protein Tree': 'protein_tree/NCBITaxon:1'
     }
     for name, href in arborist.items():
         output.append(f'      <li><a href="/arborist/{href}">{name}</a></li>')

--- a/src/util/serve.py
+++ b/src/util/serve.py
@@ -56,7 +56,8 @@ def index():
         'Proteome': 'proteome',
         'Peptide Assignments': 'peptide_assignments',
         'Source Assignments': 'source_assignments',
-        'Protein Tree': 'protein_tree/NCBITaxon:1'
+        'Protein Tree (Old)': 'protein_tree_old/NCBITaxon:1',
+        'Protein Tree (New)': 'protein_tree_new/NCBITaxon:1'
     }
     for name, href in arborist.items():
         output.append(f'      <li><a href="/arborist/{href}">{name}</a></li>')


### PR DESCRIPTION
An attempt to standardize the inputs and modify the code so `make serve` will show the peptide and source assignments generated by the protein tree codebase along with the protein tree itself.