### PR TITLE
add protein fragments to protein tree

### DIFF
--- a/src/protein_tree/protein_tree/select_proteome.py
+++ b/src/protein_tree/protein_tree/select_proteome.py
@@ -352,9 +352,9 @@ class ProteomeSelector:
   
   def get_fragment_data(self, proteome_id) -> None:
     """Get the fragment data for a proteome from UniProt API which includes:
-    chains, peptides, propeptides, signal peptides, and transit peptides."""
+    chains, initiator methionine, peptides, propeptides, signal peptides, and transit peptides."""
 
-    url = f'https://rest.uniprot.org/uniprotkb/stream?format=json&query=proteome:{proteome_id}&fields=ft_chain,ft_peptide,ft_propep,ft_signal,ft_transit'
+    url = f'https://rest.uniprot.org/uniprotkb/stream?format=json&query=proteome:{proteome_id}&fields=ft_chain,ft_init_met,ft_peptide,ft_propep,ft_signal,ft_transit'
     try:
       r = requests.get(url)
       r.raise_for_status()


### PR DESCRIPTION
For #12 

Fragment entries come from the UniProt data and will be a separate node in the protein tree if an epitope is contained within the region. Fragment data can be pull for each proteome selected via the UniProt API using this URL:

`https://rest.uniprot.org/uniprotkb/stream?format=json&query=proteome:{proteome_id}&fields=ft_chain,ft_init_met,ft_peptide,ft_propep,ft_signal,ft_transit`

and avoids downloading the entire XML or JSON file which includes every bit of data on the proteome.

Included fragment types:
1. Chain (ft_chain)
2. Initiator methionines (ft_init_met)
3. Peptide (ft_peptide)
4. Propeptide (ft_propep)
5. Signal peptide (ft_signal)
6. Transit peptide (ft_transit)

Data is pulled per `select_proteome.py` run. 

This is a draft as I need to now change `build.py` in the protein tree code to create separate nodes for them.