### PR TITLE
protein: upgrade PEPMatch to 1.17 (.pepidx index, no gzip)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,8 @@ mysql-connector-python
 sqlalchemy
 pytest
 requests
-pepmatch==1.1.2
-polars==1.2.0
+pepmatch==1.17.0
+polars==1.42.1
 
 # protein tree package
 -e ./src/protein

--- a/src/protein/protein_tree/assign.py
+++ b/src/protein/protein_tree/assign.py
@@ -99,7 +99,7 @@ class AssignmentHandler:
     files_to_remove = [
       'alignments.csv', 'alignments.tsv', 'arc-temp-results.tsv', 'peptide-matches.tsv', 'proteome.fasta.pdb',
       'proteome.fasta.phr', 'proteome.fasta.pin', 'proteome.fasta.pjs', 'proteome.fasta.pot',
-      'proteome.fasta.psq', 'proteome.fasta.ptf', 'proteome.fasta.pto', 'sources.fasta', 'proteome.tsv', 'proteome.db',
+      'proteome.fasta.psq', 'proteome.fasta.ptf', 'proteome.fasta.pto', 'sources.fasta', 'proteome.tsv',
       'allergens.fasta.pdb', 'allergens.fasta.phr', 'allergens.fasta.pin', 'allergens.fasta.pjs', 'allergens.fasta.pot',
       'allergens.fasta.psq', 'allergens.fasta.ptf', 'allergens.fasta.pto'
     ]
@@ -400,20 +400,12 @@ class PeptideProcessor:
     return True
 
   def preprocess_proteome(self):
-    db_file = self.species_path / 'proteome.db'
-    db_gz_file = self.species_path / 'proteome.db.gz'
-    if db_gz_file.exists() and not db_file.exists():
-      subprocess.run(['gunzip', '-k', str(db_gz_file)], check=True)
-
-    if (db_file).exists():
+    if (self.species_path / 'proteome_5mers.pepidx').exists():
       return
-
-    gp_proteome = self.species_path / 'gp_proteome.fasta' if (self.species_path / 'gp_proteome.fasta').exists() else ''
     Preprocessor(
       proteome = self.species_path / 'proteome.fasta',
       preprocessed_files_path = self.species_path,
-      gene_priority_proteome=gp_proteome
-    ).sql_proteome(k = 5)
+    ).preprocess(k = 5)
 
   def search_peptides(self):
     peptides = [peptide for peptide in self.peptides['Sequence'].to_list() if peptide]

--- a/src/protein/protein_tree/select_proteome.py
+++ b/src/protein/protein_tree/select_proteome.py
@@ -1,6 +1,5 @@
 import argparse
 import re
-import subprocess
 import requests
 import gzip
 import json
@@ -127,23 +126,13 @@ class ProteomeSelector:
     return max(proteome_counts.items(), key=lambda item: item[1])[0]
 
   def _get_match_count(self, peptide_seqs: list, proteome_id: str):
-    Preprocessor(
-      proteome = self.species_path / f'{proteome_id}.fasta',
-      preprocessed_files_path = self.species_path,
-    ).sql_proteome(k = 5)
-
-    Matcher(
+    matches = Matcher(
       query = peptide_seqs,
-      proteome_file = self.species_path / f'{proteome_id}.fasta', 
-      max_mismatches = 0, 
+      proteome_file = self.species_path / f'{proteome_id}.fasta',
+      max_mismatches = 0,
       k = 5,
       preprocessed_files_path = self.species_path,
-      output_format='tsv',
-      output_name=self.species_path / f'{proteome_id}-matches.tsv'
     ).match()
-
-    matches = pl.read_csv(self.species_path / f'{proteome_id}-matches.tsv', separator='\t')
-    (self.species_path / f'{proteome_id}-matches.tsv').unlink()
 
     matches = matches.filter(
       pl.col('Matched Sequence').is_not_null()
@@ -167,22 +156,14 @@ class ProteomeSelector:
     for file in self.species_path.glob('*.fasta'):
       if file.name != f'{proteome_id}.fasta':
         file.unlink()
-    for file in self.species_path.glob('*.db'):
-      file.unlink()
-    for file in self.species_path.glob('*.db.gz'):
+    for file in self.species_path.glob('*.pepidx'):
       file.unlink()
  
   def _preprocess_proteome(self):
-    gp_proteome = self.species_path / 'gp_proteome.fasta' if (self.species_path / 'gp_proteome.fasta').exists() else ''
     Preprocessor(
       proteome = self.species_path / 'proteome.fasta',
       preprocessed_files_path = self.species_path,
-      gene_priority_proteome=gp_proteome
-    ).sql_proteome(k = 5)
-
-    db_file = self.species_path / 'proteome.db'
-    if db_file.exists():
-      subprocess.run(['gzip', str(db_file)], check=True)
+    ).preprocess(k = 5)
 
   def _rename_proteome_file(self, proteome_id: str):
     (self.species_path / f'{proteome_id}.fasta').rename(self.species_path / 'proteome.fasta')

--- a/src/protein/requirements.txt
+++ b/src/protein/requirements.txt
@@ -2,7 +2,7 @@ biopython>=1.78
 lxml>=4.9.2
 mysql-connector-python>8.0.32
 pandas>=1.3.0
-pepmatch>=0.9.4
+pepmatch>=1.17.0
 sqlalchemy>=2.0.4
 pytest>=7.3.2
 requests>=2.31.0

--- a/src/protein/setup.py
+++ b/src/protein/setup.py
@@ -27,7 +27,7 @@ setup(
     'lxml>=4.9.2',
     'mysql-connector-python>=8.0.32',
     'pandas>=1.3.0',
-    'pepmatch>=0.9.4',
+    'pepmatch>=1.17.0',
     'sqlalchemy>=2.0.4',
     'pytest>=7.3.2',
     'requests>=2.31.0',


### PR DESCRIPTION
PEPMatch 1.17 replaces the SQLite .db index with a single memory-mapped .pepidx file and derives gene priority intrinsically from the proteome FASTA (first reviewed, non-isoform protein per gene), so it no longer takes a gene_priority_proteome.

- select_proteome / assign: call Preprocessor(...).preprocess(k=5), which writes proteome_5mers.pepidx per species; drop the gzip step, the .db / .db.gz handling, and the gene_priority_proteome argument.
- _get_match_count: read the Matcher DataFrame directly (auto-preprocess), no temp TSV; _remove_unselected_proteomes cleans *.pepidx not *.db.
- requirements: pepmatch==1.17.0, polars==1.42.1 (pepmatch floor bumped in src/protein too).

gp_proteome.fasta is still fetched only for the (unused) proteome.tsv 'Gene Priority' column; can be removed in a follow-up.