### PR TITLE
ops: monthly UniProt release watch for arborist-dev

### DIFF
--- a/ops/uniprot-cron/README.md
+++ b/ops/uniprot-cron/README.md
@@ -1,0 +1,114 @@
+# UniProt release watch (arborist-dev)
+
+Phase 1 of the UniProt-release → refresh → promote pipeline
+(`/home/dmx2/reviews/uniprot-release-cron-feasibility.md` §10).
+
+**This phase detects and notifies. It never runs `make`, never touches
+pepmatch-curation, never writes a byte outside `/var/lib/arborist-uniprot-watch`.**
+
+## What it does
+
+Once a month, `watch-release.py` reads three independent signals:
+
+| Signal | Why |
+|---|---|
+| `reldate.txt` (conditional GET on stored ETag) | 151 bytes; cheap 304 between releases |
+| `rest.uniprot.org` `x-uniprot-release` header | what `select_proteome.py` actually queries |
+| `reference_proteomes/RELEASE.metalink` `<version>` | says the *proteome set* landed, not just the KB |
+
+`x-api-deployment-date` is ignored on purpose — the REST API redeploys without a
+data release, so watching it produces false triggers.
+
+All three must agree, and the release must have been out for ≥48 h
+(`Last-Modified` on `reldate.txt`, or two sightings 48 h apart if that header is
+missing). Only then does it write `RELEASE-CONFIRMED-<release>` into the state
+dir and send a high-priority mail. That marker is the handoff point for the
+refresh runner in a later phase; nothing consumes it yet.
+
+Outcomes, all of which notify (silence must mean the timer is broken):
+
+| Outcome | Exit | Effect |
+|---|---|---|
+| baseline seeded (first run) | 0 | adopts the current release, no marker |
+| no new release | 0 | low-priority "timer ran" mail |
+| sources disagree (mirror mid-sync) | 0 | heads-up mail, no marker |
+| new release sighted, <48 h old | 0 | heads-up mail, no marker |
+| new release confirmed | 0 | `RELEASE-CONFIRMED-<release>` + high-priority mail |
+| poll failed | 70 | FAILED mail, `last_poll_error` in state, unit marked failed |
+| not arborist-dev | 78 | refuses immediately |
+
+## Install (run on arborist-dev, as root)
+
+```sh
+cd ~/lji/arborist                       # the arborist checkout on arborist-dev
+git fetch origin && git checkout feat/uniprot-release-cron && git pull
+
+sudo ops/uniprot-cron/install.sh "$PWD"
+```
+
+That installs `/opt/arborist-uniprot/bin/watch-release.py`, creates
+`/var/lib/arborist-uniprot-watch/` and `/var/log/arborist-uniprot/`, writes both
+systemd units with `ARBORIST_REPO` pointing at the checkout, and enables the
+monthly timer. It refuses to run anywhere but arborist-dev.
+
+Seed the baseline and prove the whole path works without waiting a month:
+
+```sh
+sudo /opt/arborist-uniprot/bin/watch-release.py --dry-run --no-notify   # reads only
+sudo systemctl start arborist-uniprot-watch.service                     # real run + mail
+systemctl status arborist-uniprot-watch.service
+journalctl -u arborist-uniprot-watch.service -n 50 --no-pager
+sudo cat /var/lib/arborist-uniprot-watch/state.json
+systemctl list-timers arborist-uniprot-watch.timer
+```
+
+The first real run reports "baseline seeded at 2026_02" — that is correct, not a
+missed release. The next distinct, settled release is the first one it announces.
+
+## Operating it
+
+```sh
+# manual kick (same thing the timer does)
+sudo systemctl start arborist-uniprot-watch.service
+
+# change the schedule
+sudo systemctl edit arborist-uniprot-watch.timer     # OnCalendar=*-*-05 06:30:00
+
+# ship a code change after a git pull
+sudo ops/uniprot-cron/install.sh "$PWD"
+
+# stop it entirely
+sudo systemctl disable --now arborist-uniprot-watch.timer
+```
+
+Optional ntfy push: uncomment `NTFY_URL` / `NTFY_TOPIC` in the service unit
+(`NTFY_USER`/`NTFY_PASSWORD` if the server needs auth). Unset = email only.
+Mail goes to `notify_email.DEFAULT_EMAIL_TO` (dmarrama@, rvita@); override with
+`WATCH_EMAIL_TO` in the unit.
+
+## Files
+
+```
+/opt/arborist-uniprot/bin/watch-release.py            the watcher
+/var/lib/arborist-uniprot-watch/state.json            release memory (survives weekly_clean)
+/var/lib/arborist-uniprot-watch/RELEASE-CONFIRMED-*   handoff marker for a later phase
+/etc/systemd/system/arborist-uniprot-watch.{service,timer}
+```
+
+State lives under `/var/lib` deliberately: `make weekly_clean` wipes
+`build/arborist/`, `cache/`, `current/` and would eat anything kept in the tree.
+
+## Containment
+
+Hostname gate in three places — `install.sh`, `watch-release.py`
+(`exit 78` unless `hostname -s` is `arborist-dev`), and `ConditionHost=arborist-dev`
+on both units. Never install this on asahidake or pepmatch-curation.
+
+## Tests
+
+`tests/test_watch_release.py`, offline, no network: `pytest tests/test_watch_release.py`.
+
+## Not in this phase
+
+`refresh-run.sh`, `diff-metrics.py`, `promote-to-prod.sh`, the build `flock`, k=3
+index generation, and anything that writes to pepmatch-curation.

--- a/ops/uniprot-cron/README.md
+++ b/ops/uniprot-cron/README.md
@@ -101,8 +101,8 @@ State lives under `/var/lib` deliberately: `make weekly_clean` wipes
 ## Containment
 
 Hostname gate in three places — `install.sh`, `watch-release.py`
-(`exit 78` unless `hostname -s` is `arborist-dev`), and `ConditionHost=arborist-dev`
-on both units. Never install this on asahidake or pepmatch-curation.
+(`exit 78` unless `hostname -s` is `arborist-dev`), and `ConditionHost=arborist-dev*`
+on both units (glob, because the box reports the FQDN `arborist-dev.lji.org`).
 
 ## Tests
 

--- a/ops/uniprot-cron/arborist-uniprot-watch.service
+++ b/ops/uniprot-cron/arborist-uniprot-watch.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=Arborist UniProt release watch (detect + notify only)
+Documentation=file:///opt/arborist-uniprot/README.md
+ConditionHost=arborist-dev
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+Environment=ARBORIST_REPO=/home/dmarrama/lji/arborist
+# Optional push; leave unset for email-only.
+# Environment=NTFY_URL=http://ntfy.internal:5681
+# Environment=NTFY_TOPIC=jobs
+ExecStart=/usr/bin/python3 /opt/arborist-uniprot/bin/watch-release.py --state-dir /var/lib/arborist-uniprot-watch
+StateDirectory=arborist-uniprot-watch
+LogsDirectory=arborist-uniprot
+TimeoutStartSec=10min
+Nice=10
+
+# It reads three URLs and writes one state dir. Nothing else.
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=read-only
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictSUIDSGID=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/uniprot-cron/arborist-uniprot-watch.service
+++ b/ops/uniprot-cron/arborist-uniprot-watch.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Arborist UniProt release watch (detect + notify only)
 Documentation=file:///opt/arborist-uniprot/README.md
-ConditionHost=arborist-dev
+# Glob: this box reports the FQDN arborist-dev.lji.org, and ConditionHost matches it whole.
+ConditionHost=arborist-dev*
 After=network-online.target
 Wants=network-online.target
 

--- a/ops/uniprot-cron/arborist-uniprot-watch.timer
+++ b/ops/uniprot-cron/arborist-uniprot-watch.timer
@@ -1,6 +1,6 @@
 [Unit]
 Description=Monthly Arborist UniProt release watch
-ConditionHost=arborist-dev
+ConditionHost=arborist-dev*
 
 [Timer]
 # Monthly (Dan steer): UniProt ships ~every 8 weeks. Manual kick:

--- a/ops/uniprot-cron/arborist-uniprot-watch.timer
+++ b/ops/uniprot-cron/arborist-uniprot-watch.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Monthly Arborist UniProt release watch
+ConditionHost=arborist-dev
+
+[Timer]
+# Monthly (Dan steer): UniProt ships ~every 8 weeks. Manual kick:
+#   systemctl start arborist-uniprot-watch.service
+OnCalendar=*-*-05 06:30:00
+Persistent=true
+RandomizedDelaySec=30m
+Unit=arborist-uniprot-watch.service
+
+[Install]
+WantedBy=timers.target

--- a/ops/uniprot-cron/install.sh
+++ b/ops/uniprot-cron/install.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Install the monthly UniProt release watch on arborist-dev. Run as root.
+#   sudo ops/uniprot-cron/install.sh [/path/to/arborist/repo]
+# Idempotent: re-run after a git pull to ship a new watch-release.py.
+set -euo pipefail
+
+[[ "$(hostname -s)" == "arborist-dev" ]] || { echo "refusing: not arborist-dev (this is $(hostname -s))"; exit 78; }
+[[ "$(id -u)" == "0" ]] || { echo "refusing: run as root (sudo)"; exit 77; }
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="${1:-$(cd "$HERE/../.." && pwd)}"
+[[ -f "$REPO/src/protein/protein_tree/notify_email.py" ]] || { echo "refusing: $REPO is not an arborist checkout"; exit 1; }
+
+install -d -m 0755 /opt/arborist-uniprot/bin /var/lib/arborist-uniprot-watch /var/log/arborist-uniprot
+install -m 0755 "$HERE/watch-release.py" /opt/arborist-uniprot/bin/watch-release.py
+install -m 0644 "$HERE/README.md" /opt/arborist-uniprot/README.md
+
+sed "s|^Environment=ARBORIST_REPO=.*|Environment=ARBORIST_REPO=$REPO|" \
+  "$HERE/arborist-uniprot-watch.service" > /etc/systemd/system/arborist-uniprot-watch.service
+install -m 0644 "$HERE/arborist-uniprot-watch.timer" /etc/systemd/system/arborist-uniprot-watch.timer
+chmod 0644 /etc/systemd/system/arborist-uniprot-watch.service
+
+systemctl daemon-reload
+systemctl enable --now arborist-uniprot-watch.timer
+
+echo "installed. repo=$REPO"
+systemctl list-timers arborist-uniprot-watch.timer --no-pager

--- a/ops/uniprot-cron/watch-release.py
+++ b/ops/uniprot-cron/watch-release.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Detect a settled UniProt release and say so. Builds nothing, promotes nothing.
+
+Three independent signals must agree before a release counts:
+  1. FTP reldate.txt          (conditional GET on the stored ETag)
+  2. rest.uniprot.org header  x-uniprot-release  (what select_proteome.py actually reads)
+  3. reference_proteomes/RELEASE.metalink <version>
+x-api-deployment-date is deliberately ignored: it moves without a data release.
+
+A new string is only *confirmed* after it has held for --stability-hours (default 48),
+which keeps a half-mirrored release from triggering anything. On confirmation the
+script writes RELEASE-CONFIRMED-<release> in the state dir; that marker is the
+handoff to the (not yet built) refresh runner. Every terminal outcome notifies --
+silence must mean the timer is broken, not that nothing happened.
+"""
+
+import argparse
+import json
+import os
+import re
+import socket
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from email.utils import parsedate_to_datetime
+from pathlib import Path
+
+BUILD_HOST = 'arborist-dev'
+STATE_DIR = Path('/var/lib/arborist-uniprot-watch')
+STABILITY_HOURS = 48
+HTTP_TIMEOUT = 30
+USER_AGENT = 'arborist-uniprot-watch/1 (+dmarrama@lji.org)'
+
+RELDATE_URL = ('https://ftp.uniprot.org/pub/databases/uniprot/current_release/'
+               'knowledgebase/complete/reldate.txt')
+REST_URL = 'https://rest.uniprot.org/uniprotkb/P05067.json'
+METALINK_URL = ('https://ftp.uniprot.org/pub/databases/uniprot/current_release/'
+                'knowledgebase/reference_proteomes/RELEASE.metalink')
+
+RELEASE_RE = re.compile(r'Release (\d{4}_\d{2})')
+SWISSPROT_DATE_RE = re.compile(r'Swiss-Prot Release \d{4}_\d{2} of (\S+)')
+METALINK_VERSION_RE = re.compile(r'<version>\s*(\d{4}_\d{2})\s*</version>')
+
+EXIT_WRONG_HOST = 78
+EXIT_FETCH_FAILED = 70
+
+
+def utcnow() -> datetime:
+  return datetime.now(timezone.utc)
+
+
+def iso(moment: datetime) -> str:
+  return moment.strftime('%Y-%m-%dT%H:%M:%SZ')
+
+
+def parse_iso(value):
+  if not value:
+    return None
+  return datetime.strptime(value, '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=timezone.utc)
+
+
+def parse_http_date(value):
+  """RFC 2822 Last-Modified -> aware datetime; None when absent or malformed."""
+  if not value:
+    return None
+  try:
+    moment = parsedate_to_datetime(value)
+  except (TypeError, ValueError):
+    return None
+  return moment if moment.tzinfo else moment.replace(tzinfo=timezone.utc)
+
+
+class FetchError(RuntimeError):
+  pass
+
+
+def _open(request):
+  try:
+    return urllib.request.urlopen(request, timeout=HTTP_TIMEOUT)
+  except urllib.error.HTTPError as error:
+    if error.code == 304:
+      return error
+    raise FetchError(f'{request.full_url}: HTTP {error.code}') from error
+  except (urllib.error.URLError, socket.timeout, OSError) as error:
+    raise FetchError(f'{request.full_url}: {error}') from error
+
+
+def fetch_reldate(etag: str) -> dict:
+  """Conditional GET; 304 means the release string is unchanged since last poll."""
+  headers = {'User-Agent': USER_AGENT}
+  if etag:
+    headers['If-None-Match'] = etag
+  response = _open(urllib.request.Request(RELDATE_URL, headers=headers))
+  if getattr(response, 'code', None) == 304:
+    return {'not_modified': True}
+  body = response.read().decode('utf-8', 'replace')
+  release = RELEASE_RE.search(body)
+  if not release:
+    raise FetchError(f'reldate.txt has no release string: {body!r}')
+  date = SWISSPROT_DATE_RE.search(body)
+  return {
+    'not_modified': False,
+    'release': release.group(1),
+    'release_date': date.group(1) if date else None,
+    'etag': response.headers.get('ETag', ''),
+    'last_modified': response.headers.get('Last-Modified', ''),
+  }
+
+
+def fetch_rest_release() -> str:
+  request = urllib.request.Request(REST_URL, headers={'User-Agent': USER_AGENT}, method='HEAD')
+  release = _open(request).headers.get('x-uniprot-release')
+  if not release:
+    raise FetchError('rest.uniprot.org sent no x-uniprot-release header')
+  return release.strip()
+
+
+def fetch_metalink_version() -> str:
+  request = urllib.request.Request(METALINK_URL, headers={'User-Agent': USER_AGENT})
+  body = _open(request).read().decode('utf-8', 'replace')
+  version = METALINK_VERSION_RE.search(body)
+  if not version:
+    raise FetchError('RELEASE.metalink has no <version>')
+  return version.group(1)
+
+
+def load_state(path: Path) -> dict:
+  if not path.exists():
+    return {}
+  return json.loads(path.read_text())
+
+
+def save_state(path: Path, state: dict) -> None:
+  path.parent.mkdir(parents=True, exist_ok=True)
+  temp = path.with_suffix('.json.tmp')
+  temp.write_text(json.dumps(state, indent=2, sort_keys=True) + '\n')
+  temp.replace(path)
+
+
+def send_email(subject: str, body: str, repo: Path) -> str:
+  """Reuse the weekly digest relay. Never fatal -- returns a status string."""
+  sys.path.insert(0, str(repo / 'src' / 'protein'))
+  try:
+    from protein_tree import notify_email
+  except ImportError as error:
+    return f'email skipped (no protein_tree at {repo}: {error})'
+  to = os.environ.get('WATCH_EMAIL_TO', notify_email.DEFAULT_EMAIL_TO)
+  html = '<pre>' + body.replace('&', '&amp;').replace('<', '&lt;') + '</pre>'
+  try:
+    message = notify_email.build_message(subject, html, to=to, text_body=body)
+    notify_email.send_email(message)
+  except Exception as error:  # observability must not break the watcher
+    return f'email FAILED: {error}'
+  return f'email sent to {to}'
+
+
+def send_ntfy(subject: str, body: str, priority: str) -> str:
+  """Optional push. Configured by NTFY_URL (+NTFY_TOPIC); silently off when unset."""
+  url = os.environ.get('NTFY_URL')
+  topic = os.environ.get('NTFY_TOPIC', 'jobs')
+  if not url:
+    return 'ntfy skipped (NTFY_URL unset)'
+  command = ['curl', '-fsS', '-m', '15',
+             '-H', f'Title: {subject}', '-H', f'Priority: {priority}', '-H', 'Tags: dna',
+             '--data-binary', body, f'{url.rstrip("/")}/{topic}']
+  user = os.environ.get('NTFY_USER')
+  password = os.environ.get('NTFY_PASSWORD')
+  if user and password:
+    command[1:1] = ['-u', f'{user}:{password}']
+  result = subprocess.run(command, capture_output=True, text=True)
+  return 'ntfy sent' if result.returncode == 0 else f'ntfy FAILED: {result.stderr.strip()}'
+
+
+def notify(subject: str, body: str, args, priority: str = 'default') -> None:
+  log(subject)
+  log(body)
+  if args.no_notify:
+    log('notifications suppressed (--no-notify)')
+    return
+  log(send_email(subject, body, args.repo))
+  log(send_ntfy(subject, body, priority))
+
+
+def log(message: str) -> None:
+  print(f'[{iso(utcnow())}] {message}', flush=True)
+
+
+def decide(state: dict, release: str, now: datetime, stability_hours: int,
+           released_at: datetime = None) -> str:
+  """known | sighted | settling | confirmed -- the outcomes for an agreed release.
+
+  A monthly timer cannot rely on two polls 48h apart, so the release's own
+  Last-Modified settles it when available; the two-poll path is the fallback.
+  """
+  if release == state.get('last_seen_release'):
+    return 'known'
+  window = timedelta(hours=stability_hours)
+  if released_at and now - released_at >= window:
+    return 'confirmed'
+  if state.get('pending_release') != release:
+    return 'sighted'
+  first_seen = parse_iso(state.get('pending_first_seen_at'))
+  if first_seen and now - first_seen >= window:
+    return 'confirmed'
+  return 'settling'
+
+
+def parse_args(argv):
+  parser = argparse.ArgumentParser(description=__doc__,
+                                   formatter_class=argparse.RawDescriptionHelpFormatter)
+  parser.add_argument('-s', '--state-dir', type=Path, default=STATE_DIR)
+  parser.add_argument('-r', '--repo', type=Path,
+                      default=Path(os.environ.get('ARBORIST_REPO', '/home/dmarrama/lji/arborist')),
+                      help='arborist checkout, for the notify_email relay')
+  parser.add_argument('--stability-hours', type=int, default=STABILITY_HOURS,
+                      help='how long a new release string must hold before it counts')
+  parser.add_argument('--no-notify', action='store_true', help='log only; no email, no ntfy')
+  parser.add_argument('--dry-run', action='store_true', help='do not write state or markers')
+  parser.add_argument('--allow-any-host', action='store_true',
+                      help='bypass the arborist-dev gate (testing only)')
+  return parser.parse_args(argv)
+
+
+def main(argv=None) -> int:
+  args = parse_args(argv)
+
+  host = socket.gethostname().split('.')[0]
+  if host != BUILD_HOST and not args.allow_any_host:
+    print(f'refusing: not {BUILD_HOST} (this is {host})', file=sys.stderr)
+    return EXIT_WRONG_HOST
+
+  state_path = args.state_dir / 'state.json'
+  state = load_state(state_path)
+  fresh_state = not state
+  now = utcnow()
+
+  released_at = None
+  try:
+    reldate = fetch_reldate(state.get('reldate_etag', ''))
+    if reldate['not_modified']:
+      reldate_release = state.get('last_seen_release')
+      log(f'reldate.txt 304 not-modified (release {reldate_release})')
+      if not reldate_release:
+        raise FetchError('reldate.txt returned 304 but no release is stored yet')
+    else:
+      reldate_release = reldate['release']
+      state['reldate_etag'] = reldate['etag']
+      state['reldate_last_modified'] = reldate['last_modified']
+      state['last_seen_release_date'] = reldate['release_date']
+    released_at = parse_http_date(state.get('reldate_last_modified', ''))
+    rest_release = fetch_rest_release()
+    metalink_release = fetch_metalink_version()
+  except FetchError as error:
+    state['last_poll_at'] = iso(now)
+    state['last_poll_error'] = str(error)
+    if not args.dry_run:
+      save_state(state_path, state)
+    notify('Arborist UniProt watch FAILED',
+           f'Release poll failed, no release decision made.\n\n{error}\n\n'
+           f'Host: {host}\nState: {state_path}\n'
+           'The monthly check did not complete -- fix the fetch or the box.',
+           args, priority='high')
+    return EXIT_FETCH_FAILED
+
+  state['last_poll_at'] = iso(now)
+  state.pop('last_poll_error', None)
+  state['rest_release_header'] = rest_release
+  state['metalink_version'] = metalink_release
+  log(f'reldate={reldate_release} rest={rest_release} metalink={metalink_release}')
+
+  sources = {reldate_release, rest_release, metalink_release}
+  if len(sources) != 1:
+    state['pending_release'] = None
+    state['pending_first_seen_at'] = None
+    if not args.dry_run:
+      save_state(state_path, state)
+    notify(f'Arborist UniProt watch: sources disagree ({", ".join(sorted(sources))})',
+           f'reldate.txt={reldate_release}\nrest x-uniprot-release={rest_release}\n'
+           f'RELEASE.metalink={metalink_release}\n\n'
+           'Likely a mirror mid-sync. No refresh triggered; next monthly poll re-checks.',
+           args)
+    return 0
+
+  release = sources.pop()
+  verdict = decide(state, release, now, args.stability_hours, released_at)
+
+  if fresh_state:
+    # First run on a new box: adopt whatever UniProt is on now. Announcing the
+    # current release as "new" would be a lie and would arm the refresh path.
+    state['last_seen_release'] = release
+    state['first_seen_at'] = iso(released_at or now)
+    state['confirmed_at'] = iso(now)
+    state['last_notified_at'] = iso(now)
+    state['pending_release'] = None
+    state['pending_first_seen_at'] = None
+    if not args.dry_run:
+      save_state(state_path, state)
+    notify(f'Arborist UniProt watch: baseline seeded at {release}',
+           f'Watch installed on {host}; adopting current release {release} as the baseline.\n'
+           'No refresh triggered. The next distinct, settled release will be reported.',
+           args, priority='low')
+    return 0
+
+  if verdict == 'known':
+    log(f'no new release (still {release})')
+    if not args.dry_run:
+      save_state(state_path, state)
+    notify(f'Arborist UniProt watch: no new release ({release})',
+           f'UniProt is still on {release}; last confirmed {state.get("confirmed_at")}.\n'
+           'Nothing to refresh. This mail proves the monthly timer ran.',
+           args, priority='low')
+    return 0
+
+  if verdict == 'sighted':
+    state['pending_release'] = release
+    state['pending_first_seen_at'] = iso(now)
+    state['last_notified_at'] = iso(now)
+    if not args.dry_run:
+      save_state(state_path, state)
+    notify(f'Arborist UniProt watch: {release} sighted (unconfirmed)',
+           f'All three sources report {release} (was {state.get("last_seen_release")}).\n'
+           f'Holding for {args.stability_hours}h of stability before confirming.\n'
+           'Nothing was built. Re-run the watch after the window to confirm.',
+           args)
+    return 0
+
+  if verdict == 'settling':
+    first_seen = state.get('pending_first_seen_at')
+    log(f'{release} still settling since {first_seen}; no notification')
+    if not args.dry_run:
+      save_state(state_path, state)
+    return 0
+
+  previous = state.get('last_seen_release')
+  state['last_seen_release'] = release
+  state['first_seen_at'] = state.get('pending_first_seen_at') or iso(released_at or now)
+  state['confirmed_at'] = iso(now)
+  state['last_notified_at'] = iso(now)
+  state['pending_release'] = None
+  state['pending_first_seen_at'] = None
+  marker = args.state_dir / f'RELEASE-CONFIRMED-{release}'
+  if not args.dry_run:
+    save_state(state_path, state)
+    marker.write_text(f'confirmed_at={iso(now)}\nprevious={previous}\n')
+  age = f'released {iso(released_at)}' if released_at else 'release date unknown'
+  notify(f'Arborist UniProt watch: {release} CONFIRMED',
+         f'UniProt {release} is settled ({age}; previous {previous}).\n'
+         f'Marker: {marker}\n\n'
+         'This watcher builds nothing. Refresh on arborist-dev is still manual:\n'
+         '  make weekly_clean && make deps iedb ncbitaxon organism proteome protein\n'
+         '(under flock /var/lock/arborist-build.lock, ALERT_EMAIL=0)',
+         args, priority='high')
+  return 0
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/tests/test_watch_release.py
+++ b/tests/test_watch_release.py
@@ -1,0 +1,221 @@
+"""Offline coverage for the monthly UniProt release watch (ops/uniprot-cron)."""
+
+import importlib.util
+import json
+import socket
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).parent.parent / 'ops' / 'uniprot-cron' / 'watch-release.py'
+
+
+@pytest.fixture(scope='module')
+def watch():
+  spec = importlib.util.spec_from_file_location('watch_release', SCRIPT)
+  module = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(module)
+  return module
+
+
+RELDATE_BODY = (
+  'UniProt Knowledgebase Release 2026_03 consists of:\n'
+  'UniProtKB/Swiss-Prot Release 2026_03 of 05-Aug-2026\n'
+  'UniProtKB/TrEMBL Release 2026_03 of 05-Aug-2026\n'
+)
+
+METALINK_BODY = (
+  '<metalink xmlns="http://www.metalinker.org/" version="3.0">\n'
+  '  <version>2026_03</version>\n</metalink>\n'
+)
+
+
+class FakeResponse:
+  def __init__(self, body='', headers=None, code=200):
+    self._body = body.encode()
+    self.headers = headers or {}
+    self.code = code
+
+  def read(self):
+    return self._body
+
+
+def wire(watch, monkeypatch, *, reldate, rest='2026_03', metalink=METALINK_BODY,
+         last_modified='Wed, 05 Aug 2026 20:00:00 GMT', etag='"new-etag"'):
+  """Route the three signal fetches to canned responses; nothing hits the network."""
+  def fake_open(request):
+    url = request.full_url
+    if 'reldate.txt' in url:
+      if reldate is None:  # server says 304
+        return FakeResponse(code=304)
+      return FakeResponse(reldate, {'ETag': etag, 'Last-Modified': last_modified})
+    if 'rest.uniprot.org' in url:
+      return FakeResponse(headers={'x-uniprot-release': rest})
+    if 'RELEASE.metalink' in url:
+      return FakeResponse(metalink)
+    raise AssertionError(f'unexpected fetch: {url}')
+
+  monkeypatch.setattr(watch, '_open', fake_open)
+  monkeypatch.setattr(watch, 'notify', lambda *a, **k: None)
+
+
+def run(watch, state_dir, *extra):
+  return watch.main(['--state-dir', str(state_dir), '--allow-any-host', '--no-notify', *extra])
+
+
+def read_state(state_dir):
+  return json.loads((state_dir / 'state.json').read_text())
+
+
+def seed(state_dir, release='2026_02'):
+  """A watch that has already adopted a baseline release."""
+  state_dir.mkdir(parents=True, exist_ok=True)
+  (state_dir / 'state.json').write_text(json.dumps({
+    'last_seen_release': release, 'confirmed_at': '2026-06-13T00:00:00Z',
+  }))
+
+
+def test_first_run_adopts_current_release_without_alarm(watch, tmp_path, monkeypatch):
+  """Fresh install must not report today's release as new, nor arm a refresh."""
+  wire(watch, monkeypatch, reldate=RELDATE_BODY)
+  monkeypatch.setattr(watch, 'utcnow',
+                      lambda: datetime(2026, 8, 10, tzinfo=timezone.utc))
+
+  assert run(watch, tmp_path) == 0
+
+  state = read_state(tmp_path)
+  assert state['last_seen_release'] == '2026_03'
+  assert not list(tmp_path.glob('RELEASE-CONFIRMED-*'))
+
+
+def test_wrong_host_fails_closed(watch, tmp_path, monkeypatch, capsys):
+  monkeypatch.setattr(socket, 'gethostname', lambda: 'asahidake')
+  assert watch.main(['--state-dir', str(tmp_path)]) == watch.EXIT_WRONG_HOST
+  assert 'refusing' in capsys.readouterr().err
+  assert not (tmp_path / 'state.json').exists()
+
+
+def test_settled_release_confirms_and_writes_marker(watch, tmp_path, monkeypatch):
+  seed(tmp_path)
+  wire(watch, monkeypatch, reldate=RELDATE_BODY)
+  monkeypatch.setattr(watch, 'utcnow',
+                      lambda: datetime(2026, 8, 10, tzinfo=timezone.utc))
+
+  assert run(watch, tmp_path) == 0
+
+  state = read_state(tmp_path)
+  assert state['last_seen_release'] == '2026_03'
+  assert state['confirmed_at'] == '2026-08-10T00:00:00Z'
+  assert state['pending_release'] is None
+  assert (tmp_path / 'RELEASE-CONFIRMED-2026_03').exists()
+
+
+def test_fresh_release_is_sighted_not_confirmed(watch, tmp_path, monkeypatch):
+  """Inside the 48h window a release is announced, never acted on."""
+  seed(tmp_path)
+  wire(watch, monkeypatch, reldate=RELDATE_BODY)
+  monkeypatch.setattr(watch, 'utcnow',
+                      lambda: datetime(2026, 8, 5, 23, 0, tzinfo=timezone.utc))
+
+  assert run(watch, tmp_path) == 0
+
+  state = read_state(tmp_path)
+  assert state['pending_release'] == '2026_03'
+  assert state['last_seen_release'] == '2026_02'
+  assert not (tmp_path / 'RELEASE-CONFIRMED-2026_03').exists()
+
+
+def test_two_poll_fallback_confirms_without_last_modified(watch, tmp_path, monkeypatch):
+  """No usable Last-Modified: the stored first-sighting timestamp settles it."""
+  seed(tmp_path)
+  wire(watch, monkeypatch, reldate=RELDATE_BODY, last_modified='')
+  monkeypatch.setattr(watch, 'utcnow',
+                      lambda: datetime(2026, 8, 5, 23, 0, tzinfo=timezone.utc))
+  assert run(watch, tmp_path) == 0
+  assert read_state(tmp_path)['pending_release'] == '2026_03'
+
+  monkeypatch.setattr(watch, 'utcnow',
+                      lambda: datetime(2026, 8, 8, 23, 0, tzinfo=timezone.utc))
+  assert run(watch, tmp_path) == 0
+  state = read_state(tmp_path)
+  assert state['last_seen_release'] == '2026_03'
+  assert state['first_seen_at'] == '2026-08-05T23:00:00Z'
+
+
+def test_source_disagreement_never_confirms(watch, tmp_path, monkeypatch):
+  """A mirror mid-sync (REST still on the old release) must not trigger anything."""
+  seed(tmp_path)
+  wire(watch, monkeypatch, reldate=RELDATE_BODY, rest='2026_02')
+  monkeypatch.setattr(watch, 'utcnow',
+                      lambda: datetime(2026, 8, 10, tzinfo=timezone.utc))
+
+  assert run(watch, tmp_path) == 0
+
+  state = read_state(tmp_path)
+  assert state['last_seen_release'] == '2026_02'
+  assert state['pending_release'] is None
+  assert not list(tmp_path.glob('RELEASE-CONFIRMED-*'))
+
+
+def test_known_release_is_a_no_op(watch, tmp_path, monkeypatch):
+  (tmp_path / 'state.json').write_text(json.dumps({
+    'last_seen_release': '2026_03', 'reldate_etag': '"old"',
+    'confirmed_at': '2026-08-07T00:00:00Z',
+  }))
+  wire(watch, monkeypatch, reldate=None)  # 304 on the stored ETag
+  monkeypatch.setattr(watch, 'utcnow',
+                      lambda: datetime(2026, 8, 20, tzinfo=timezone.utc))
+
+  assert run(watch, tmp_path) == 0
+
+  state = read_state(tmp_path)
+  assert state['last_seen_release'] == '2026_03'
+  assert state['last_poll_at'] == '2026-08-20T00:00:00Z'
+  assert not list(tmp_path.glob('RELEASE-CONFIRMED-*'))
+
+
+def test_fetch_failure_reports_and_exits_nonzero(watch, tmp_path, monkeypatch):
+  """Silence must mean broken: a failed poll records the error and exits 70."""
+  def boom(request):
+    raise watch.FetchError('ftp.uniprot.org: timed out')
+
+  monkeypatch.setattr(watch, '_open', boom)
+  monkeypatch.setattr(watch, 'notify', lambda *a, **k: None)
+
+  assert run(watch, tmp_path) == watch.EXIT_FETCH_FAILED
+  assert 'timed out' in read_state(tmp_path)['last_poll_error']
+
+
+def test_dry_run_writes_nothing(watch, tmp_path, monkeypatch):
+  state_dir = tmp_path / 'state'
+  seed(state_dir)
+  before = (state_dir / 'state.json').read_text()
+  wire(watch, monkeypatch, reldate=RELDATE_BODY)
+  monkeypatch.setattr(watch, 'utcnow',
+                      lambda: datetime(2026, 8, 10, tzinfo=timezone.utc))
+
+  assert run(watch, state_dir, '--dry-run') == 0
+  assert (state_dir / 'state.json').read_text() == before
+  assert not list(state_dir.glob('RELEASE-CONFIRMED-*'))
+
+
+def test_deployment_date_is_not_a_signal(watch):
+  """x-api-deployment-date redeploys independently; it must not appear anywhere."""
+  source = SCRIPT.read_text()
+  assert 'x-uniprot-release' in source
+  assert 'x-api-deployment-date' not in source.split('"""', 2)[2]
+
+
+@pytest.mark.parametrize('stored,released,expected', [
+  ({'last_seen_release': '2026_03'}, None, 'known'),
+  ({}, datetime(2026, 8, 5, tzinfo=timezone.utc), 'confirmed'),
+  ({}, datetime(2026, 8, 9, 12, tzinfo=timezone.utc), 'sighted'),
+  ({'pending_release': '2026_03', 'pending_first_seen_at': '2026-08-09T00:00:00Z'},
+   None, 'settling'),
+  ({'pending_release': '2026_03', 'pending_first_seen_at': '2026-08-07T00:00:00Z'},
+   None, 'confirmed'),
+])
+def test_decide_matrix(watch, stored, released, expected):
+  now = datetime(2026, 8, 10, tzinfo=timezone.utc)
+  assert watch.decide(stored, '2026_03', now, 48, released) == expected


### PR DESCRIPTION
Phase 1 of the UniProt-release pipeline: detect and notify only.

- `ops/uniprot-cron/watch-release.py` — monthly check of three agreeing signals (reldate.txt ETag, rest `x-uniprot-release`, RELEASE.metalink); 48h settle via the release's own Last-Modified; writes `RELEASE-CONFIRMED-<release>` and emails. Runs no `make`, touches no prod.
- systemd service + timer, `ConditionHost=arborist-dev*`, state under `/var/lib/arborist-uniprot-watch/` so `weekly_clean` cannot eat it.
- `install.sh`, README, and 15 offline tests.

Verified live on arborist-dev: baseline seeded at 2026_02, mail delivered, timer armed for 2026-08-05.