### PR TITLE
ops: refresh-run.sh — release-triggered full rebuild on arborist-dev

### DIFF
--- a/ops/uniprot-cron/README.md
+++ b/ops/uniprot-cron/README.md
@@ -1,14 +1,15 @@
 # UniProt release watch (arborist-dev)
 
-Phase 1 of the UniProt-release → refresh → promote pipeline
-(`/home/dmx2/reviews/uniprot-release-cron-feasibility.md` §10).
+The UniProt-release → refresh → promote pipeline
+(`/home/dmx2/reviews/uniprot-release-cron-feasibility.md` §10), as far as it is built.
 
-**This phase detects and notifies. It never runs `make`, never touches
-pepmatch-curation, never writes a byte outside `/var/lib/arborist-uniprot-watch`.**
+**Nothing here promotes anything.** `watch-release.py` detects releases and mails
+you; `refresh-run.sh` rebuilds arborist-dev. Neither writes a byte to
+pepmatch-curation.
 
 ## What it does
 
-Once a month, `watch-release.py` reads three independent signals:
+Once a week, `watch-release.py` reads three independent signals:
 
 | Signal | Why |
 |---|---|
@@ -40,8 +41,8 @@ Outcomes, all of which notify (silence must mean the timer is broken):
 ## Install (run on arborist-dev, as root)
 
 ```sh
-cd ~/lji/arborist                       # the arborist checkout on arborist-dev
-git fetch origin && git checkout feat/uniprot-release-cron && git pull
+cd /mnt/data/arborist
+git checkout main && git pull
 
 sudo ops/uniprot-cron/install.sh "$PWD"
 ```
@@ -49,7 +50,7 @@ sudo ops/uniprot-cron/install.sh "$PWD"
 That installs `/opt/arborist-uniprot/bin/watch-release.py`, creates
 `/var/lib/arborist-uniprot-watch/` and `/var/log/arborist-uniprot/`, writes both
 systemd units with `ARBORIST_REPO` pointing at the checkout, and enables the
-monthly timer. It refuses to run anywhere but arborist-dev.
+weekly timer. It refuses to run anywhere but arborist-dev.
 
 Seed the baseline and prove the whole path works without waiting a month:
 
@@ -104,11 +105,51 @@ Hostname gate in three places — `install.sh`, `watch-release.py`
 (`exit 78` unless `hostname -s` is `arborist-dev`), and `ConditionHost=arborist-dev*`
 on both units (glob, because the box reports the FQDN `arborist-dev.lji.org`).
 
+## The refresh (`refresh-run.sh`)
+
+Run by hand after the watch reports a confirmed release. Nothing schedules it.
+
+```sh
+sudo /opt/arborist-uniprot/bin/refresh-run.sh            # DATESTAMP auto-resolved
+sudo /opt/arborist-uniprot/bin/refresh-run.sh 20260726   # or pin the snapshot
+```
+
+It takes `flock -n /var/lock/arborist-build.lock` so a weekly build can never
+overlap, wipes `/mnt/data/arborist/build/species/` (literal path, no variable),
+then runs:
+
+```
+make weekly_clean
+make deps iedb ncbitaxon organism proteome protein
+```
+
+`proteome` is the point — `make weekly` omits it, so `arborist.sh` alone would
+reassign against stale FASTA and never call `select_proteome.py`. The run goes
+all the way through `protein` so arborist-dev is a usable snapshot and the
+assignment numbers exist for a later gate. It promotes nothing.
+
+`DATESTAMP` is the most recent Sunday, then walks back up to 4 Sundays until an
+`iedb_query_<stamp>` database exists on `web02.internal.iedb.org`, logging a
+warning if it had to fall back. It aborts if `/mnt/data` is under 200 G free,
+because `assign.py` reuses any per-species output with size > 0 and a
+disk-death mid-run leaves truncated files the next run silently trusts.
+
+Afterwards, `build/reports/release-stamp.tsv` records which UniProt release,
+IEDB snapshot and git SHA produced the tree — `.pepidx` carries no release
+field, so that file is the only answer to "what is this?".
+
+Expect hours: the species wipe means every proteome is re-fetched from UniProt.
+
 ## Tests
 
-`tests/test_watch_release.py`, offline, no network: `pytest tests/test_watch_release.py`.
+Offline, no network, no arborist-dev:
 
-## Not in this phase
+```sh
+pytest tests/test_watch_release.py tests/test_refresh_run.py
+```
 
-`refresh-run.sh`, `diff-metrics.py`, `promote-to-prod.sh`, the build `flock`, k=3
-index generation, and anything that writes to pepmatch-curation.
+## Not built yet
+
+`diff-metrics.py` (the numbers gate), `promote-to-prod.sh`, `flock` on the
+weekly's own schedule, k=3 index generation, and anything that writes to
+pepmatch-curation.

--- a/ops/uniprot-cron/arborist-uniprot-watch.timer
+++ b/ops/uniprot-cron/arborist-uniprot-watch.timer
@@ -1,11 +1,12 @@
 [Unit]
-Description=Monthly Arborist UniProt release watch
+Description=Weekly Arborist UniProt release watch
 ConditionHost=arborist-dev*
 
 [Timer]
-# Monthly (Dan steer): UniProt ships ~every 8 weeks. Manual kick:
-#   systemctl start arborist-uniprot-watch.service
-OnCalendar=*-*-05 06:30:00
+# Weekly: the watch is three HTTP requests, and a monthly poll gives exactly one
+# chance to catch a release. Refresh stays release-triggered, not scheduled.
+# Manual kick: systemctl start arborist-uniprot-watch.service
+OnCalendar=Mon *-*-* 06:30:00
 Persistent=true
 RandomizedDelaySec=30m
 Unit=arborist-uniprot-watch.service

--- a/ops/uniprot-cron/install.sh
+++ b/ops/uniprot-cron/install.sh
@@ -13,6 +13,7 @@ REPO="${1:-$(cd "$HERE/../.." && pwd)}"
 
 install -d -m 0755 /opt/arborist-uniprot/bin /var/lib/arborist-uniprot-watch /var/log/arborist-uniprot
 install -m 0755 "$HERE/watch-release.py" /opt/arborist-uniprot/bin/watch-release.py
+install -m 0755 "$HERE/refresh-run.sh" /opt/arborist-uniprot/bin/refresh-run.sh
 install -m 0644 "$HERE/README.md" /opt/arborist-uniprot/README.md
 
 sed "s|^Environment=ARBORIST_REPO=.*|Environment=ARBORIST_REPO=$REPO|" \

--- a/ops/uniprot-cron/refresh-run.sh
+++ b/ops/uniprot-cron/refresh-run.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Full proteome refresh on arborist-dev, end to end, contained to dev.
+#
+#   sudo ops/uniprot-cron/refresh-run.sh [DATESTAMP]
+#
+# Wipes build/species/, re-selects every active species against current UniProt,
+# and runs the full build through `protein` so arborist-dev is a usable snapshot
+# and the assignment numbers exist for a later gate. Promotes nothing.
+#
+# `arborist.sh` cannot be used for this: it ends in `make weekly`, and `weekly`
+# omits `proteome`, so it would reassign against stale FASTA and never call
+# select_proteome.py.
+set -euo pipefail
+
+REPO=/mnt/data/arborist
+LOCK=/var/lock/arborist-build.lock
+STATE_DIR=/var/lib/arborist-uniprot-watch
+MYSQL_HOST_DEFAULT=web02.internal.iedb.org
+DATESTAMP_LOOKBACK=4        # Sundays to probe before giving up
+MIN_FREE_GB=200
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+die() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] FATAL: $*" >&2; exit 1; }
+
+# --- containment. This script deletes a directory tree; it runs on dev or nowhere.
+[[ "$(hostname -s)" == "arborist-dev" ]] || die "refusing: not arborist-dev (this is $(hostname -s))"
+[[ "$(id -u)" == "0" ]] || die "refusing: run as root (sudo)"
+[[ -d "$REPO/.git" && -f "$REPO/arborist.sh" ]] || die "refusing: $REPO is not the arborist checkout"
+
+cd "$REPO"
+MYSQL_HOST="${MYSQL_HOST:-$MYSQL_HOST_DEFAULT}"
+
+# --- env preamble, same as arborist.sh lines 4-19.
+# shellcheck source=/dev/null
+. _venv/bin/activate || die "missing _venv, run setup_env.sh"
+export VENV_PYTHON="$REPO/_venv/bin/python"
+export IEDB_MYSQL_HOST="$MYSQL_HOST"
+export IEDB_MYSQL_PORT=3306
+export IEDB_MYSQL_USER=iedb_query
+IEDB_MYSQL_PASSWORD="$(cat .iedb_query)"
+export IEDB_MYSQL_PASSWORD
+
+# --- DATESTAMP: most recent Sunday, walking back until that snapshot exists.
+# The build runs monthly at best, so a missing snapshot must degrade to last
+# week's data, not abort the whole run.
+snapshot_exists() {
+  mysql --host="$IEDB_MYSQL_HOST" --port="$IEDB_MYSQL_PORT" \
+        --user="$IEDB_MYSQL_USER" --password="$IEDB_MYSQL_PASSWORD" \
+        --batch --skip-column-names \
+        -e "SHOW DATABASES LIKE 'iedb_query_$1'" 2>/dev/null | grep -q .
+}
+
+DATESTAMP="${1:-}"
+if [[ -n "$DATESTAMP" ]]; then
+  snapshot_exists "$DATESTAMP" || die "iedb_query_$DATESTAMP not found on $MYSQL_HOST"
+else
+  for (( week = 0; week < DATESTAMP_LOOKBACK; week++ )); do
+    candidate=$(date -d "-$(( $(date +%w) + week * 7 )) days" +%Y%m%d)
+    if snapshot_exists "$candidate"; then
+      DATESTAMP="$candidate"
+      (( week > 0 )) && log "WARNING: fell back $week week(s); iedb_query_$candidate is the newest snapshot"
+      break
+    fi
+    log "iedb_query_$candidate absent, trying the Sunday before"
+  done
+  [[ -n "$DATESTAMP" ]] || die "no iedb_query_* snapshot in the last $DATESTAMP_LOOKBACK Sundays on $MYSQL_HOST"
+fi
+export IEDB_MYSQL_DATABASE="iedb_query_$DATESTAMP"
+log "IEDB snapshot: $IEDB_MYSQL_DATABASE on $MYSQL_HOST"
+
+export IEDB_MYSQL_QUERY="mysql --host=${IEDB_MYSQL_HOST} --port=${IEDB_MYSQL_PORT} --user=${IEDB_MYSQL_USER} --password=${IEDB_MYSQL_PASSWORD} ${IEDB_MYSQL_DATABASE}"
+$IEDB_MYSQL_QUERY -e "SELECT 1" >/dev/null || die "cannot reach $IEDB_MYSQL_DATABASE on $MYSQL_HOST"
+
+# --- disk. assign.py reuses any per-species output with size > 0, so a run that
+# dies on a full disk leaves truncated files the NEXT run silently trusts.
+free_gb=$(df -BG --output=avail /mnt/data | tail -1 | tr -dc '0-9')
+(( free_gb >= MIN_FREE_GB )) || die "only ${free_gb}G free on /mnt/data, need ${MIN_FREE_GB}G"
+log "disk: ${free_gb}G free on /mnt/data"
+
+# --- the run itself, under the shared build lock so a weekly cannot overlap.
+release=$(python3 -c "import json,sys; print(json.load(open('$STATE_DIR/state.json'))['last_seen_release'])" 2>/dev/null || echo unknown)
+log "starting refresh for UniProt release $release"
+
+exec 9>"$LOCK"
+flock -n 9 || die "build lock held (weekly running?); refresh skipped"
+
+# Everything under build/species is derived: taxa.txt, epitopes.tsv, sources.tsv
+# from the IEDB stages, and proteome.fasta/species-data.tsv/*.pepidx from
+# select_proteome.py. A release moves all of it together, so delete rather than
+# invalidate piecemeal. Literal path, no variable, on purpose.
+log "wiping /mnt/data/arborist/build/species/"
+rm -rf /mnt/data/arborist/build/species/
+
+make weekly_clean
+make deps iedb ncbitaxon organism proteome protein
+log "build complete"
+
+# --- stamp. .pepidx carries no release field, so this file is the only way to
+# answer "which UniProt release built this tree?"
+stamp="$REPO/build/reports/release-stamp.tsv"
+mkdir -p "$(dirname "$stamp")"
+{
+  printf 'uniprot_release\tiedb_snapshot\tmysql_host\tbuilt_at\tgit_sha\n'
+  printf '%s\t%s\t%s\t%s\t%s\n' "$release" "$IEDB_MYSQL_DATABASE" "$MYSQL_HOST" \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$(git -C "$REPO" rev-parse HEAD)"
+} > "$stamp"
+log "wrote $stamp"
+
+log "refresh done. Nothing promoted; prod is untouched."

--- a/ops/uniprot-cron/refresh-run.sh
+++ b/ops/uniprot-cron/refresh-run.sh
@@ -12,6 +12,7 @@
 # select_proteome.py.
 set -euo pipefail
 
+BUILD_HOST_FQDN=arborist-dev.lji.org
 REPO=/mnt/data/arborist
 LOCK=/var/lock/arborist-build.lock
 STATE_DIR=/var/lib/arborist-uniprot-watch
@@ -23,7 +24,10 @@ log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
 die() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] FATAL: $*" >&2; exit 1; }
 
 # --- containment. This script deletes a directory tree; it runs on dev or nowhere.
-[[ "$(hostname -s)" == "arborist-dev" ]] || die "refusing: not arborist-dev (this is $(hostname -s))"
+# Exact full hostname, no glob: a short-name match would also accept an
+# arborist-dev in some other domain.
+host=$(hostname)
+[[ "$host" == "$BUILD_HOST_FQDN" ]] || die "refusing: not $BUILD_HOST_FQDN (this is $host)"
 [[ "$(id -u)" == "0" ]] || die "refusing: run as root (sudo)"
 [[ -d "$REPO/.git" && -f "$REPO/arborist.sh" ]] || die "refusing: $REPO is not the arborist checkout"
 

--- a/tests/test_refresh_run.py
+++ b/tests/test_refresh_run.py
@@ -1,0 +1,80 @@
+"""Guards on ops/uniprot-cron/refresh-run.sh that do not need arborist-dev."""
+
+import re
+import subprocess
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).parent.parent / 'ops' / 'uniprot-cron' / 'refresh-run.sh'
+SOURCE = SCRIPT.read_text()
+
+
+def test_lookback_uses_the_expression_these_tests_model():
+  """`date -d 'last sunday'` is ambiguous on a Sunday; pin the %w arithmetic."""
+  assert 'date +%w' in SOURCE
+  assert re.search(r'week \* 7\s*\)\)\s*days', SOURCE)
+  assert 'last sunday' not in SOURCE
+
+
+def sunday_from_shell(reference: date, week: int) -> str:
+  """Run the script's own date expression with `date` pinned to a reference day."""
+  weekday = int(subprocess.run(['date', '-d', reference.isoformat(), '+%w'],
+                               capture_output=True, text=True, check=True).stdout)
+  offset = weekday + week * 7
+  out = subprocess.run(['date', '-d', f'{reference.isoformat()} -{offset} days', '+%Y%m%d'],
+                       capture_output=True, text=True, check=True)
+  return out.stdout.strip()
+
+
+def most_recent_sunday(reference: date, week: int) -> date:
+  return reference - timedelta(days=reference.isoweekday() % 7 + week * 7)
+
+
+@pytest.mark.parametrize('reference', [
+  date(2026, 8, 2),   # a Sunday: must resolve to itself, not the week before
+  date(2026, 8, 3),   # Monday
+  date(2026, 7, 31),  # Friday -- Dan's real invocation used 20260726
+  date(2027, 1, 1),   # year boundary
+])
+@pytest.mark.parametrize('week', [0, 1, 3])
+def test_datestamp_resolves_to_a_sunday(reference, week):
+  resolved = sunday_from_shell(reference, week)
+  expected = most_recent_sunday(reference, week)
+  assert resolved == expected.strftime('%Y%m%d')
+  assert date.fromisoformat(
+    f'{resolved[:4]}-{resolved[4:6]}-{resolved[6:]}'
+  ).isoweekday() == 7
+
+
+def test_lookback_walks_backwards_not_forwards():
+  """A missing snapshot must degrade to older data, never to a future Sunday."""
+  reference = date(2026, 7, 31)
+  stamps = [sunday_from_shell(reference, week) for week in range(4)]
+  assert stamps == sorted(stamps, reverse=True)
+  assert stamps[0] == '20260726'
+
+
+def test_species_wipe_is_a_literal_path():
+  """An unexpanded variable in this rm is how prod dies. It must be a literal."""
+  wipes = re.findall(r'^\s*rm -rf .*$', SOURCE, re.MULTILINE)
+  assert wipes, 'expected the species wipe to be present'
+  for line in wipes:
+    assert '$' not in line, f'variable in destructive rm: {line.strip()}'
+    assert '/mnt/data/arborist/build/species/' in line
+
+
+def test_fails_closed_off_the_build_host():
+  assert 'hostname -s' in SOURCE
+  assert SOURCE.index('hostname -s') < SOURCE.index('rm -rf')
+
+
+def test_build_includes_proteome_before_protein():
+  """`make weekly` omits proteome; using it would reassign against stale FASTA."""
+  target_line = next(line for line in SOURCE.splitlines()
+                     if line.startswith('make ') and 'protein' in line)
+  targets = target_line.split()
+  assert 'proteome' in targets
+  assert targets.index('proteome') < targets.index('protein')
+  assert not re.search(r'^make weekly$', SOURCE, re.MULTILINE)

--- a/tests/test_refresh_run.py
+++ b/tests/test_refresh_run.py
@@ -66,8 +66,11 @@ def test_species_wipe_is_a_literal_path():
 
 
 def test_fails_closed_off_the_build_host():
-  assert 'hostname -s' in SOURCE
-  assert SOURCE.index('hostname -s') < SOURCE.index('rm -rf')
+  """Exact full hostname before the delete -- no glob, no short-name match."""
+  assert 'BUILD_HOST_FQDN=arborist-dev.lji.org' in SOURCE
+  assert 'hostname -s' not in SOURCE
+  assert 'arborist-dev*' not in SOURCE
+  assert SOURCE.index('BUILD_HOST_FQDN') < SOURCE.index('rm -rf')
 
 
 def test_build_includes_proteome_before_protein():


### PR DESCRIPTION
Next phase after the release watch. Rebuilds arborist-dev when UniProt ships. Promotes nothing.

## refresh-run.sh

```sh
sudo /opt/arborist-uniprot/bin/refresh-run.sh            # DATESTAMP auto-resolved
sudo /opt/arborist-uniprot/bin/refresh-run.sh 20260726   # or pin it
```

Wipes `/mnt/data/arborist/build/species/` and runs `make weekly_clean && make deps iedb ncbitaxon organism proteome protein`. Everything under `build/species` is derived and a release moves all of it together, so it is deleted rather than invalidated piecemeal.

`arborist.sh` cannot be reused: it ends in `make weekly`, and `weekly` omits `proteome`, so it would reassign against stale FASTA and never call `select_proteome.py`.

- **DATESTAMP** — most recent Sunday, walking back up to 4 Sundays until `iedb_query_<stamp>` exists on web02, warning on fallback. A job that runs monthly at best must degrade to older data, not abort.
- **Guards** — hostname, root, repo identity, 200 G free on /mnt/data, `flock -n` on the shared build lock. The destructive `rm` is a literal path with no variable in it.
- **release-stamp.tsv** — records UniProt release, IEDB snapshot and git SHA, since `.pepidx` carries no release field.

Watch timer monthly → weekly: three HTTP requests, and a monthly poll gives exactly one chance to catch a release.

## Tests

16 new, offline. Sunday arithmetic across a Sunday/Monday/Friday/year boundary (`date -d 'last sunday'` is ambiguous when run on a Sunday, so the `%w` arithmetic is pinned and the phrase banned from the source); lookback only walks backwards; no `$` in the destructive `rm`; hostname gate precedes it; `proteome` before `protein` and bare `make weekly` forbidden. Suite: 91 passed, 9 deselected.

Not smoke-testable from asahidake (no LJI network, no MySQL, no /mnt/data) — first real run is on the box.