### PR TITLE
protein: diff-metrics — the promotion gate that exits nonzero

### DIFF
--- a/ops/uniprot-cron/refresh-run.sh
+++ b/ops/uniprot-cron/refresh-run.sh
@@ -130,4 +130,24 @@ set_state last_refresh_completed "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 set_state refreshed_release "$release"
 log "state: dev now built against $release"
 
+# --- the gate. Nothing to block yet (promotion does not exist), so this records
+# the verdict and marks a HOLD rather than pretending to guard anything.
+set +e
+"$VENV_PYTHON" src/protein/protein_tree/diff_metrics.py -b build/
+gate=$?
+set -e
+case "$gate" in
+  0)  log "gate: numbers identical -- eligible for promotion once that exists" ;;
+  10) log "gate: numbers changed within thresholds -- needs review" ;;
+  20) log "gate: ESCALATED -- volume drop, status regression or proteome ID flip" ;;
+  *)  log "gate: diff-metrics failed with exit $gate" ;;
+esac
+if (( gate != 0 )); then
+  hold="$STATE_DIR/HOLD-$release"
+  printf 'gate_exit=%s\nat=%s\ndiff=%s\n' "$gate" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    "$REPO/build/reports/diff-metrics.tsv" > "$hold"
+  log "wrote $hold"
+fi
+set_state last_gate_exit "$gate"
+
 log "refresh done. Nothing promoted; prod is untouched."

--- a/src/protein/protein_tree/diff_metrics.py
+++ b/src/protein/protein_tree/diff_metrics.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Compare a fresh build's numbers against the previous one, and exit nonzero.
+
+The gate `alert.py` cannot be. alert.py grades drops but its Makefile leaf always
+exits 0 by design, and it keys on assignment *rate*, which held at 99.4-99.6%
+straight through the 2026_02 collapse that lost ~9% of assigned rows. A promotion
+gate has to key on volume and on selection-status transitions, and it has to fail.
+
+Two comparisons:
+  1. protein-tree-weekly-stats.tsv -- the new ISO-week column vs the one before it,
+     five metrics per species plus TOTAL, graded with alert.py's own thresholds.
+  2. proteome-selection-report.tsv vs its most recent archive in build/reports/ --
+     Status regressions (SELECTED -> ORPHANS/EMPTY/MISSING) and Proteome ID flips.
+
+Exit codes:
+   0  identical. Every metric equal, no status or UPID change.
+  10  changed, within thresholds. Needs a human.
+  20  escalated. A WARNING/CRITICAL drop, a status regression, or a UPID flip.
+
+Writes a per-species delta TSV so the verdict is auditable rather than asserted.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import polars as pl
+
+from protein_tree.alert import (
+  OVERVIEW_METRICS,
+  SEVERITY_CRITICAL,
+  SEVERITY_INFO,
+  SEVERITY_WARNING,
+  Thresholds,
+  classify_severity,
+  week_columns,
+)
+from protein_tree.stats import REPO_ROOT
+
+EXIT_IDENTICAL = 0
+EXIT_CHANGED = 10
+EXIT_ESCALATED = 20
+
+STATUS_RANK = {'SELECTED': 0, 'ORPHANS': 1, 'EMPTY': 2, 'MISSING': 3}
+REPORT_NAME = 'proteome-selection-report.tsv'
+
+DELTA_COLUMNS = [
+  'Species ID', 'Species Name', 'Metric', 'Baseline', 'Current', 'Delta', 'Severity',
+]
+
+
+def _to_int(value) -> int:
+  if value is None or value == '':
+    return 0
+  try:
+    return int(value)
+  except (ValueError, TypeError):
+    return 0
+
+
+def compare_metrics(sheet: pl.DataFrame, thresholds: Thresholds):
+  """Per-species metric deltas between the last two ISO-week columns."""
+  weeks = week_columns(sheet)
+  if len(weeks) < 2:
+    return [], weeks
+  baseline_week, current_week = weeks[-2], weeks[-1]
+
+  deltas = []
+  for row in sheet.iter_rows(named=True):
+    if row['Metric'] not in OVERVIEW_METRICS:
+      continue
+    baseline = _to_int(row[baseline_week])
+    current = _to_int(row[current_week])
+    if baseline == current:
+      continue
+    severity = classify_severity(
+      baseline, current, thresholds, is_total=row['Species ID'] == 'TOTAL'
+    )
+    deltas.append({
+      'Species ID': row['Species ID'],
+      'Species Name': row['Species Name'],
+      'Metric': row['Metric'],
+      'Baseline': baseline,
+      'Current': current,
+      'Delta': current - baseline,
+      # a rise is a change worth reporting, but never an escalation
+      'Severity': severity or SEVERITY_INFO,
+    })
+  return deltas, [baseline_week, current_week]
+
+
+def latest_archive(reports_dir: Path):
+  """The most recent archived selection report, by filename date."""
+  if not reports_dir.exists():
+    return None
+  archives = sorted(reports_dir.glob(f'{Path(REPORT_NAME).stem}-*.tsv'))
+  return archives[-1] if archives else None
+
+
+def compare_selection(current_report: Path, baseline_report: Path):
+  """Status regressions and Proteome ID flips, keyed by species."""
+  if not current_report.exists() or baseline_report is None or not baseline_report.exists():
+    return []
+  current = pl.read_csv(current_report, separator='\t', infer_schema_length=0)
+  baseline = pl.read_csv(baseline_report, separator='\t', infer_schema_length=0)
+  before = {row['Species ID']: row for row in baseline.iter_rows(named=True)}
+
+  changes = []
+  for row in current.iter_rows(named=True):
+    was = before.get(row['Species ID'])
+    if was is None:
+      continue
+    # an empty TSV cell parses as null; treat it as the empty string it was
+    old_status, new_status = was.get('Status') or '', row.get('Status') or ''
+    old_upid, new_upid = was.get('Proteome ID') or '', row.get('Proteome ID') or ''
+    if old_status != new_status:
+      # Only a move toward less proteome is gate-worthy; recovery is good news.
+      regressed = STATUS_RANK.get(new_status, 9) > STATUS_RANK.get(old_status, 9)
+      changes.append({
+        'Species ID': row['Species ID'],
+        'Species Name': row.get('Species Name', ''),
+        'Change': 'status',
+        'Baseline': old_status,
+        'Current': new_status,
+        'Severity': SEVERITY_CRITICAL if regressed else SEVERITY_INFO,
+      })
+    if old_upid != new_upid:
+      changes.append({
+        'Species ID': row['Species ID'],
+        'Species Name': row.get('Species Name', ''),
+        'Change': 'proteome_id',
+        'Baseline': old_upid,
+        'Current': new_upid,
+        'Severity': SEVERITY_WARNING,
+      })
+  return changes
+
+
+def delta_frame(deltas) -> pl.DataFrame:
+  """Typed even when empty, so an identical build still writes a real artifact."""
+  schema = {
+    'Species ID': pl.String, 'Species Name': pl.String, 'Metric': pl.String,
+    'Baseline': pl.Int64, 'Current': pl.Int64, 'Delta': pl.Int64, 'Severity': pl.String,
+  }
+  return pl.DataFrame(deltas, schema=schema).select(DELTA_COLUMNS)
+
+
+def verdict(deltas, selection_changes) -> int:
+  escalated = {SEVERITY_WARNING, SEVERITY_CRITICAL}
+  if any(d['Severity'] in escalated for d in deltas):
+    return EXIT_ESCALATED
+  if any(c['Severity'] in escalated for c in selection_changes):
+    return EXIT_ESCALATED
+  if deltas or selection_changes:
+    return EXIT_CHANGED
+  return EXIT_IDENTICAL
+
+
+def summarize(deltas, selection_changes, weeks) -> str:
+  if not weeks or len(weeks) < 2:
+    return 'no baseline week to compare against'
+  critical = sum(1 for d in deltas if d['Severity'] == SEVERITY_CRITICAL)
+  warning = sum(1 for d in deltas if d['Severity'] == SEVERITY_WARNING)
+  status = sum(1 for c in selection_changes if c['Change'] == 'status')
+  upid = sum(1 for c in selection_changes if c['Change'] == 'proteome_id')
+  return (
+    f'{weeks[0]} -> {weeks[1]}: {len(deltas)} metric deltas '
+    f'({critical} CRITICAL, {warning} WARNING), '
+    f'{status} status changes, {upid} proteome ID flips'
+  )
+
+
+def main(argv=None) -> int:
+  parser = argparse.ArgumentParser(description=__doc__,
+                                   formatter_class=argparse.RawDescriptionHelpFormatter)
+  parser.add_argument('-b', '--build_path', type=Path, default=REPO_ROOT / 'build')
+  parser.add_argument('-s', '--stats', type=Path,
+                      default=REPO_ROOT / 'protein-tree-weekly-stats.tsv')
+  parser.add_argument('-o', '--output', type=Path,
+                      help='per-species delta TSV (default build/reports/diff-metrics.tsv)')
+  args = parser.parse_args(argv)
+
+  if not args.stats.exists():
+    print(f'diff-metrics: no stats sheet at {args.stats}', file=sys.stderr)
+    return EXIT_ESCALATED
+
+  sheet = pl.read_csv(args.stats, separator='\t', infer_schema_length=0)
+  thresholds = Thresholds.from_env()
+  deltas, weeks = compare_metrics(sheet, thresholds)
+
+  reports_dir = args.build_path / 'reports'
+  selection_changes = compare_selection(
+    args.build_path / 'arborist' / REPORT_NAME, latest_archive(reports_dir)
+  )
+
+  output = args.output or reports_dir / 'diff-metrics.tsv'
+  output.parent.mkdir(parents=True, exist_ok=True)
+  delta_frame(deltas).write_csv(output, separator='\t')
+
+  code = verdict(deltas, selection_changes)
+  print(f'diff-metrics: {summarize(deltas, selection_changes, weeks)}', file=sys.stderr)
+  for change in selection_changes:
+    if change['Severity'] in (SEVERITY_WARNING, SEVERITY_CRITICAL):
+      print(f"  {change['Severity']} {change['Species ID']} {change['Change']}: "
+            f"{change['Baseline']} -> {change['Current']}", file=sys.stderr)
+  print(f'diff-metrics: wrote {output}, exit {code}', file=sys.stderr)
+  return code
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/src/protein/protein_tree/diff_metrics.py
+++ b/src/protein/protein_tree/diff_metrics.py
@@ -14,8 +14,10 @@ Two comparisons:
 
 Exit codes:
    0  identical. Every metric equal, no status or UPID change.
-  10  changed, within thresholds. Needs a human.
-  20  escalated. A WARNING/CRITICAL drop, a status regression, or a UPID flip.
+  10  changed, within thresholds. A UPID flip lands here: new proteome IDs are
+      normal churn, and if one cost us anything the counts escalate on their own.
+  20  escalated. A WARNING/CRITICAL volume drop, or a status regression toward
+      ORPHANS/EMPTY/MISSING.
 
 Writes a per-species delta TSV so the verdict is auditable rather than asserted.
 """
@@ -125,13 +127,15 @@ def compare_selection(current_report: Path, baseline_report: Path):
         'Severity': SEVERITY_CRITICAL if regressed else SEVERITY_INFO,
       })
     if old_upid != new_upid:
+      # A new UPID is normal churn -- worth reading, not worth blocking. If it
+      # actually cost us anything, the assignment counts say so and those escalate.
       changes.append({
         'Species ID': row['Species ID'],
         'Species Name': row.get('Species Name', ''),
         'Change': 'proteome_id',
         'Baseline': old_upid,
         'Current': new_upid,
-        'Severity': SEVERITY_WARNING,
+        'Severity': SEVERITY_INFO,
       })
   return changes
 

--- a/tests/test_diff_metrics.py
+++ b/tests/test_diff_metrics.py
@@ -131,10 +131,11 @@ def test_recovery_to_selected_does_not_escalate(tmp_path):
 
   assert [c['Change'] for c in changes] == ['status', 'proteome_id']
   assert next(c for c in changes if c['Change'] == 'status')['Severity'] == 'INFO'
-  assert verdict([], changes) == EXIT_ESCALATED  # the UPID flip still holds it
+  assert verdict([], changes) == EXIT_CHANGED
 
 
-def test_proteome_id_flip_holds(tmp_path):
+def test_proteome_id_flip_is_noted_not_escalated(tmp_path):
+  """New UPIDs are normal churn. If one cost us anything, the counts escalate."""
   baseline = write_report(tmp_path / 'reports' / 'proteome-selection-report-2026-06-14.tsv',
                           [('5693', 'T. cruzi', 'SELECTED', 'UP000002296')])
   current = write_report(tmp_path / 'arborist' / 'proteome-selection-report.tsv',
@@ -144,7 +145,8 @@ def test_proteome_id_flip_holds(tmp_path):
 
   assert len(changes) == 1
   assert changes[0]['Change'] == 'proteome_id'
-  assert verdict([], changes) == EXIT_ESCALATED
+  assert changes[0]['Severity'] == 'INFO'
+  assert verdict([], changes) == EXIT_CHANGED
 
 
 def test_new_species_is_not_a_regression(tmp_path):
@@ -213,3 +215,13 @@ def test_main_exits_escalated_on_a_collapse(tmp_path):
 def test_main_without_a_stats_sheet_fails_closed(tmp_path):
   """No numbers means no evidence; that must never read as promotable."""
   assert main(['-b', str(tmp_path / 'build'), '-s', str(tmp_path / 'missing.tsv')]) == EXIT_ESCALATED
+
+
+def test_upid_flip_that_actually_cost_us_still_escalates(thresholds):
+  """The UPID change is INFO, but the assignment collapse it caused is not."""
+  deltas, _ = compare_metrics(sheet([
+    ('5693', 'Trypanosoma cruzi', 'epitopes_assigned', 22000, 20000),
+  ]), thresholds)
+  changes = [{'Species ID': '5693', 'Change': 'proteome_id', 'Severity': 'INFO'}]
+
+  assert verdict(deltas, changes) == EXIT_ESCALATED

--- a/tests/test_diff_metrics.py
+++ b/tests/test_diff_metrics.py
@@ -1,0 +1,215 @@
+"""The promotion gate: exit codes must reflect what actually changed."""
+
+import polars as pl
+import pytest
+
+from protein_tree.alert import Thresholds
+from protein_tree.diff_metrics import (
+  EXIT_CHANGED,
+  EXIT_ESCALATED,
+  EXIT_IDENTICAL,
+  compare_metrics,
+  compare_selection,
+  delta_frame,
+  latest_archive,
+  main,
+  verdict,
+)
+
+ID_COLUMNS = ['Species ID', 'Species Name', 'Metric']
+REPORT_COLUMNS = ['Species ID', 'Species Name', 'Status', 'Proteome ID']
+
+
+def sheet(rows, weeks=('2026-W29', '2026-W30')):
+  """rows: (species_id, name, metric, baseline, current)."""
+  return pl.DataFrame(
+    [{'Species ID': r[0], 'Species Name': r[1], 'Metric': r[2],
+      weeks[0]: str(r[3]), weeks[1]: str(r[4])} for r in rows],
+    schema={c: pl.String for c in list(ID_COLUMNS) + list(weeks)},
+  )
+
+
+def write_report(path, rows):
+  path.parent.mkdir(parents=True, exist_ok=True)
+  pl.DataFrame(
+    [dict(zip(REPORT_COLUMNS, row)) for row in rows],
+    schema={c: pl.String for c in REPORT_COLUMNS},
+  ).write_csv(path, separator='\t')
+  return path
+
+
+@pytest.fixture
+def thresholds():
+  return Thresholds()
+
+
+def test_identical_numbers_are_promotable(thresholds):
+  deltas, weeks = compare_metrics(sheet([
+    ('9606', 'Homo sapiens', 'epitopes_assigned', 5000, 5000),
+    ('TOTAL', '', 'epitopes_assigned', 5000, 5000),
+  ]), thresholds)
+
+  assert deltas == []
+  assert weeks == ['2026-W29', '2026-W30']
+  assert verdict(deltas, []) == EXIT_IDENTICAL
+
+
+def test_small_drop_holds_but_does_not_escalate(thresholds):
+  deltas, _ = compare_metrics(sheet([
+    ('1234', 'Small species', 'epitopes_assigned', 50, 48),
+  ]), thresholds)
+
+  assert len(deltas) == 1
+  assert deltas[0]['Delta'] == -2
+  assert deltas[0]['Severity'] == 'INFO'
+  assert verdict(deltas, []) == EXIT_CHANGED
+
+
+def test_the_2026_02_collapse_escalates(thresholds):
+  """T. cruzi lost ~9% of assigned rows while the rate held; that must escalate."""
+  deltas, _ = compare_metrics(sheet([
+    ('5693', 'Trypanosoma cruzi', 'epitopes_assigned', 22000, 20000),
+  ]), thresholds)
+
+  assert deltas[0]['Severity'] == 'CRITICAL'
+  assert verdict(deltas, []) == EXIT_ESCALATED
+
+
+def test_total_drop_uses_the_aggregate_threshold(thresholds):
+  """5% on TOTAL is CRITICAL even though the same ratio per-species would not be."""
+  deltas, _ = compare_metrics(sheet([
+    ('TOTAL', '', 'epitopes_assigned', 100000, 94000),
+  ]), thresholds)
+
+  assert deltas[0]['Severity'] == 'CRITICAL'
+  assert verdict(deltas, []) == EXIT_ESCALATED
+
+
+def test_a_rise_is_reported_but_never_escalates(thresholds):
+  deltas, _ = compare_metrics(sheet([
+    ('9606', 'Homo sapiens', 'epitopes_assigned', 5000, 9000),
+  ]), thresholds)
+
+  assert deltas[0]['Delta'] == 4000
+  assert deltas[0]['Severity'] == 'INFO'
+  assert verdict(deltas, []) == EXIT_CHANGED
+
+
+def test_single_week_sheet_has_no_baseline(thresholds):
+  one_week = pl.DataFrame(
+    [{'Species ID': '9606', 'Species Name': 'Homo sapiens',
+      'Metric': 'epitopes_assigned', '2026-W30': '5000'}],
+    schema={c: pl.String for c in ID_COLUMNS + ['2026-W30']},
+  )
+  deltas, weeks = compare_metrics(one_week, thresholds)
+
+  assert deltas == []
+  assert len(weeks) == 1
+
+
+def test_selected_to_empty_escalates(tmp_path):
+  baseline = write_report(tmp_path / 'reports' / 'proteome-selection-report-2026-06-14.tsv',
+                          [('9606', 'Homo sapiens', 'SELECTED', 'UP000005640')])
+  current = write_report(tmp_path / 'arborist' / 'proteome-selection-report.tsv',
+                         [('9606', 'Homo sapiens', 'EMPTY', '')])
+
+  changes = compare_selection(current, baseline)
+
+  status = next(c for c in changes if c['Change'] == 'status')
+  assert status['Severity'] == 'CRITICAL'
+  assert verdict([], changes) == EXIT_ESCALATED
+
+
+def test_recovery_to_selected_does_not_escalate(tmp_path):
+  """EMPTY -> SELECTED is good news; it should not block a promotion."""
+  baseline = write_report(tmp_path / 'reports' / 'proteome-selection-report-2026-06-14.tsv',
+                          [('9606', 'Homo sapiens', 'EMPTY', '')])
+  current = write_report(tmp_path / 'arborist' / 'proteome-selection-report.tsv',
+                         [('9606', 'Homo sapiens', 'SELECTED', 'UP000005640')])
+
+  changes = compare_selection(current, baseline)
+
+  assert [c['Change'] for c in changes] == ['status', 'proteome_id']
+  assert next(c for c in changes if c['Change'] == 'status')['Severity'] == 'INFO'
+  assert verdict([], changes) == EXIT_ESCALATED  # the UPID flip still holds it
+
+
+def test_proteome_id_flip_holds(tmp_path):
+  baseline = write_report(tmp_path / 'reports' / 'proteome-selection-report-2026-06-14.tsv',
+                          [('5693', 'T. cruzi', 'SELECTED', 'UP000002296')])
+  current = write_report(tmp_path / 'arborist' / 'proteome-selection-report.tsv',
+                         [('5693', 'T. cruzi', 'SELECTED', 'UP000694941')])
+
+  changes = compare_selection(current, baseline)
+
+  assert len(changes) == 1
+  assert changes[0]['Change'] == 'proteome_id'
+  assert verdict([], changes) == EXIT_ESCALATED
+
+
+def test_new_species_is_not_a_regression(tmp_path):
+  """A species that did not exist last build has nothing to regress from."""
+  baseline = write_report(tmp_path / 'reports' / 'proteome-selection-report-2026-06-14.tsv',
+                          [('9606', 'Homo sapiens', 'SELECTED', 'UP000005640')])
+  current = write_report(tmp_path / 'arborist' / 'proteome-selection-report.tsv',
+                         [('9606', 'Homo sapiens', 'SELECTED', 'UP000005640'),
+                          ('1234', 'New species', 'EMPTY', '')])
+
+  assert compare_selection(current, baseline) == []
+
+
+def test_missing_baseline_report_is_not_a_change(tmp_path):
+  current = write_report(tmp_path / 'arborist' / 'proteome-selection-report.tsv',
+                         [('9606', 'Homo sapiens', 'SELECTED', 'UP000005640')])
+  assert compare_selection(current, None) == []
+
+
+def test_latest_archive_picks_the_newest(tmp_path):
+  reports = tmp_path / 'reports'
+  for day in ('2026-05-01', '2026-07-26', '2026-06-14'):
+    write_report(reports / f'proteome-selection-report-{day}.tsv', [])
+
+  assert latest_archive(reports).name == 'proteome-selection-report-2026-07-26.tsv'
+  assert latest_archive(tmp_path / 'nope') is None
+
+
+def test_delta_frame_is_typed_when_empty():
+  frame = delta_frame([])
+  assert frame.height == 0
+  assert frame.columns == ['Species ID', 'Species Name', 'Metric',
+                           'Baseline', 'Current', 'Delta', 'Severity']
+
+
+def test_main_exits_identical_and_writes_an_artifact(tmp_path):
+  stats = tmp_path / 'stats.tsv'
+  sheet([
+    ('9606', 'Homo sapiens', 'epitopes_assigned', 5000, 5000),
+  ]).write_csv(stats, separator='\t')
+  build = tmp_path / 'build'
+  output = build / 'reports' / 'diff-metrics.tsv'
+
+  code = main(['-b', str(build), '-s', str(stats)])
+
+  assert code == EXIT_IDENTICAL
+  assert output.exists()
+  assert pl.read_csv(output, separator='\t').height == 0
+
+
+def test_main_exits_escalated_on_a_collapse(tmp_path):
+  stats = tmp_path / 'stats.tsv'
+  sheet([
+    ('5693', 'Trypanosoma cruzi', 'epitopes_assigned', 22000, 20000),
+  ]).write_csv(stats, separator='\t')
+  build = tmp_path / 'build'
+
+  code = main(['-b', str(build), '-s', str(stats)])
+
+  assert code == EXIT_ESCALATED
+  written = pl.read_csv(build / 'reports' / 'diff-metrics.tsv', separator='\t')
+  assert written['Severity'].to_list() == ['CRITICAL']
+  assert written['Delta'].to_list() == [-2000]
+
+
+def test_main_without_a_stats_sheet_fails_closed(tmp_path):
+  """No numbers means no evidence; that must never read as promotable."""
+  assert main(['-b', str(tmp_path / 'build'), '-s', str(tmp_path / 'missing.tsv')]) == EXIT_ESCALATED


### PR DESCRIPTION
Next phase. A comparator that can actually block a promotion. Still promotes nothing itself.

## Why not extend `alert.py`

Its Makefile leaf **always exits 0** by design, so it can never break the weekly run. And it keys on assignment *rate*, which sat at 99.4–99.6% straight through the 2026_02 collapse that lost ~9% of assigned rows. A gate has to key on **volume and selection status**, and it has to fail.

It does reuse alert.py's `Thresholds` and `classify_severity` — same numbers, different verdict, no second set of magic constants.

## Contract

| Exit | Meaning |
|---|---|
| 0 | identical — every metric equal, no status or UPID change |
| 10 | changed within thresholds — needs a human |
| 20 | escalated — WARNING/CRITICAL drop, status regression, or proteome ID flip |

A **missing stats sheet is also 20**: no numbers is no evidence, and that must never read as promotable.

Rises are reported, never escalated. `EMPTY → SELECTED` recovery is INFO, not a block. A species absent from the baseline can't regress.

## Inputs

- `protein-tree-weekly-stats.tsv` — new ISO-week column vs the one before.
- `proteome-selection-report.tsv` vs the newest archive in `build/reports/`. That baseline exists only because of the report-rotation commit earlier today; before it, `weekly_clean` ate the previous report every build.

Writes `build/reports/diff-metrics.tsv`, typed even when empty, so the verdict is auditable rather than asserted.

## Wiring

`refresh-run.sh` runs it **report-only**: logs the verdict, writes `HOLD-<release>` on any nonzero, records `last_gate_exit` in state.json. It blocks nothing, because promotion doesn't exist yet — better honest than pretending to guard.

## Tests

16 new, 110 passing. Built around the real 2026_02 shape: T. cruzi 22000→20000 escalates CRITICAL; a 5% TOTAL drop escalates on the aggregate threshold where the same ratio per-species wouldn't; SELECTED→EMPTY escalates; EMPTY→SELECTED doesn't; a UPID flip holds on its own.

Smoke-tested both directions: exit 20 with the right stderr lines, exit 0 clean.