### PR TITLE
ops: promote-to-prod — dev → arborist (full mirror) + pepmatch-curation (indexes)

### DIFF
--- a/ops/uniprot-cron/README.md
+++ b/ops/uniprot-cron/README.md
@@ -3,19 +3,22 @@
 The UniProt-release → refresh → promote pipeline
 (`/home/dmx2/reviews/uniprot-release-cron-feasibility.md` §10), as far as it is built.
 
-**Nothing here promotes anything.** `watch-release.py` detects releases and mails
-you; `refresh-run.sh` rebuilds arborist-dev. Neither writes a byte to
-pepmatch-curation.
+`watch-release.py` detects releases and mails you. `refresh-run.sh` rebuilds
+arborist-dev. `promote-to-prod.sh` is the only script that writes to prod or
+pepmatch-curation, and it refuses without a clean gate or your approval.
 
 ## What do I run?
 
-Everything below runs on **arborist-dev**, as root. Nothing here touches prod.
+Everything below runs on **arborist-dev**, as root. Only the promote reaches off-box.
 
 | When | Command |
 |---|---|
 | After any `git pull` of this repo | `sudo ops/uniprot-cron/install.sh "$PWD"` |
 | A CONFIRMED release mail arrived | `sudo nohup /opt/arborist-uniprot/bin/refresh-run.sh > /var/log/arborist-uniprot/refresh.log 2>&1 &` |
 | Check on a running refresh | `tail -f /var/log/arborist-uniprot/refresh.log` |
+| Refresh finished, numbers reviewed | `sudo /opt/arborist-uniprot/bin/promote-to-prod.sh --dry-run` |
+| Ready to push dev → prod + pepmatch | `sudo nohup /opt/arborist-uniprot/bin/promote-to-prod.sh --confirm > /var/log/arborist-uniprot/promote.log 2>&1 &` |
+| Why was a promote refused? | `cat /var/lib/arborist-uniprot-watch/HOLD-*` and `build/reports/diff-metrics.tsv` |
 | Did the watch run? | `journalctl -u arborist-uniprot-watch.service -n 30 --no-pager` |
 | What release are we on? | `cat /var/lib/arborist-uniprot-watch/state.json` |
 | Poll UniProt right now | `sudo systemctl start arborist-uniprot-watch.service` |
@@ -191,16 +194,59 @@ Afterwards, `build/reports/release-stamp.tsv` records which UniProt release,
 IEDB snapshot and git SHA produced the tree — `.pepidx` carries no release
 field, so that file is the only answer to "what is this?".
 
+## The promote (`promote-to-prod.sh`)
+
+The only script here that writes outside arborist-dev. Two destinations:
+
+| Destination | Payload |
+|---|---|
+| `arborist` (prod) | all of `build/species/` — a full mirror, `--delete`, ~83 G |
+| `dmarrama@pepmatch-curation` | every `.pepidx`, flattened into `/media/data/pepmatch/proteomes/` as `<taxon>_<k>mers.pepidx` |
+
+```sh
+sudo /opt/arborist-uniprot/bin/promote-to-prod.sh --dry-run   # writes nothing
+sudo nohup /opt/arborist-uniprot/bin/promote-to-prod.sh --confirm \
+  > /var/log/arborist-uniprot/promote.log 2>&1 &
+```
+
+It refuses unless `last_gate_exit` is 0 **or** you approved the release:
+
+```sh
+mv /var/lib/arborist-uniprot-watch/HOLD-<release> \
+   /var/lib/arborist-uniprot-watch/APPROVED-<release>
+```
+
+Order of operations: check the gate → prove both hosts reachable → build k=3
+indexes → hardlink-snapshot prod's tree → mirror to prod → sync indexes to
+pepmatch-curation → checksum both → drop the snapshot → record
+`last_sync_completed`.
+
+The snapshot is `cp -al`, not a copy: prod has 104 G free and the tree is 83 G,
+so a real copy would nearly fill the disk. Hardlinks cost directory entries, and
+rsync replaces files by rename, so the snapshot keeps the old inodes. Any failure
+after that point leaves `build/species.prev-<release>` in place for rollback;
+success deletes it.
+
+**k=3 indexes.** Arborist only ever builds k=5. pepmatch-curation also serves
+3-mers for eight heavily queried species — 9606, 10090, 10116, 9612, 9796, 9823,
+9913, 9986 — built by `preprocess_3mers.py` right before the push, reusing
+pepmatch's own `Preprocessor`. Idempotent: an index newer than its FASTA is left
+alone.
+
+ssh is `BatchMode=yes` throughout, so a missing key fails in seconds instead of
+hanging. prod uses root's key; pepmatch-curation uses the existing
+`/home/dmarrama/.ssh/pepmatch_curation_rsa` rather than a second credential.
+
 ## Tests
 
 Offline, no network, no arborist-dev:
 
 ```sh
-pytest tests/test_watch_release.py tests/test_refresh_run.py
+pytest tests/
 ```
 
 ## Not built yet
 
-`diff-metrics.py` (the numbers gate), `promote-to-prod.sh`, `flock` on the
-weekly's own schedule, k=3 index generation, and anything that writes to
-pepmatch-curation.
+`flock` on the weekly build's own schedule (so a weekly and a refresh can never
+overlap from the weekly's side), and automatic promotion — every promote is
+still a command you type.

--- a/ops/uniprot-cron/install.sh
+++ b/ops/uniprot-cron/install.sh
@@ -14,6 +14,7 @@ REPO="${1:-$(cd "$HERE/../.." && pwd)}"
 install -d -m 0755 /opt/arborist-uniprot/bin /var/lib/arborist-uniprot-watch /var/log/arborist-uniprot
 install -m 0755 "$HERE/watch-release.py" /opt/arborist-uniprot/bin/watch-release.py
 install -m 0755 "$HERE/refresh-run.sh" /opt/arborist-uniprot/bin/refresh-run.sh
+install -m 0755 "$HERE/promote-to-prod.sh" /opt/arborist-uniprot/bin/promote-to-prod.sh
 install -m 0644 "$HERE/README.md" /opt/arborist-uniprot/README.md
 
 sed "s|^Environment=ARBORIST_REPO=.*|Environment=ARBORIST_REPO=$REPO|" \

--- a/ops/uniprot-cron/promote-to-prod.sh
+++ b/ops/uniprot-cron/promote-to-prod.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Push a refreshed arborist-dev tree to the two hosts that consume it.
+#
+#   sudo ops/uniprot-cron/promote-to-prod.sh --dry-run
+#   sudo ops/uniprot-cron/promote-to-prod.sh --confirm
+#
+#   arborist.lji.org          <- all of build/species/, a full mirror
+#   pepmatch-curation.lji.org <- every .pepidx, flattened into one directory
+#
+# Refuses unless the gate passed or Dan approved. This is the only script in the
+# pipeline that writes outside arborist-dev.
+set -euo pipefail
+
+BUILD_HOST_FQDN=arborist-dev.lji.org
+REPO=/mnt/data/arborist
+SPECIES_DIR="$REPO/build/species"
+STATE_DIR=/var/lib/arborist-uniprot-watch
+
+PROD_HOST=arborist
+PROD_SPECIES=/mnt/data/arborist/build/species
+PEPMATCH_HOST=dmarrama@pepmatch-curation
+PEPMATCH_DIR=/media/data/pepmatch/proteomes
+
+# root@arborist-dev already has a key to prod. pepmatch-curation is reached with
+# the existing dmarrama key rather than minting a second one; root can read it.
+PEPMATCH_KEY=/home/dmarrama/.ssh/pepmatch_curation_rsa
+
+SSH_OPTS=(-o BatchMode=yes -o ConnectTimeout=15)
+PEPMATCH_SSH=("${SSH_OPTS[@]}" -i "$PEPMATCH_KEY" -o IdentitiesOnly=yes)
+
+pepmatch_ssh_cmd() { echo "ssh ${PEPMATCH_SSH[*]}"; }
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+die() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] FATAL: $*" >&2; exit 1; }
+
+confirm=0
+dry_run=0
+for arg in "$@"; do
+  case "$arg" in
+    --confirm) confirm=1 ;;
+    --dry-run) dry_run=1 ;;
+    *) die "unknown argument: $arg (expected --confirm or --dry-run)" ;;
+  esac
+done
+(( confirm || dry_run )) || die "refusing: pass --dry-run to preview or --confirm to promote"
+
+host=$(hostname)
+[[ "$host" == "$BUILD_HOST_FQDN" ]] || die "refusing: not $BUILD_HOST_FQDN (this is $host)"
+[[ "$(id -u)" == "0" ]] || die "refusing: run as root (sudo)"
+[[ -d "$SPECIES_DIR" ]] || die "refusing: no $SPECIES_DIR to promote"
+
+cd "$REPO"
+release=$(python3 -c "import json;print(json.load(open('$STATE_DIR/state.json'))['last_seen_release'])" 2>/dev/null || echo unknown)
+gate_exit=$(python3 -c "import json;print(json.load(open('$STATE_DIR/state.json')).get('last_gate_exit','none'))" 2>/dev/null || echo none)
+
+# --- the gate. Numbers unchanged promotes itself; anything else needs Dan.
+approval="$STATE_DIR/APPROVED-$release"
+if [[ "$gate_exit" == "0" ]]; then
+  log "gate: diff-metrics exited 0 for $release"
+elif [[ -f "$approval" ]]; then
+  log "gate: $approval present, proceeding on Dan's approval"
+else
+  die "refusing: gate exit is '$gate_exit' and no $approval. Review build/reports/diff-metrics.tsv, then: mv $STATE_DIR/HOLD-$release $approval"
+fi
+
+# --- reachability, before anything expensive or destructive.
+[[ -r "$PEPMATCH_KEY" ]] || die "missing $PEPMATCH_KEY (the pepmatch-curation key)"
+ssh "${SSH_OPTS[@]}" "$PROD_HOST" true || die "cannot ssh $PROD_HOST as root"
+ssh "${PEPMATCH_SSH[@]}" "$PEPMATCH_HOST" true \
+  || die "cannot ssh $PEPMATCH_HOST with $PEPMATCH_KEY"
+log "both destinations reachable"
+
+# --- k=3 indexes. Arborist only builds k=5; pepmatch-curation serves 3-mers for
+# a short list of heavily queried species.
+if (( dry_run )); then
+  log "dry-run: skipping 3-mer build"
+else
+  "$REPO/_venv/bin/python" src/protein/protein_tree/preprocess_3mers.py -b build/ \
+    || die "3-mer preprocessing failed"
+fi
+
+rsync_common=(-aH --info=progress2 --partial-dir=.rsync-partial)
+(( dry_run )) && rsync_common+=(-n)
+
+# --- prod: hardlink snapshot first. Costs directory entries, not 83G, and rsync
+# replaces files by rename so the snapshot keeps the old inodes intact.
+snapshot="$PROD_SPECIES.prev-$release"
+if (( dry_run )); then
+  log "dry-run: would snapshot $PROD_HOST:$snapshot"
+else
+  log "snapshotting $PROD_HOST:$snapshot"
+  ssh "${SSH_OPTS[@]}" "$PROD_HOST" \
+    "rm -rf '$snapshot' && cp -al '$PROD_SPECIES' '$snapshot'" \
+    || die "could not snapshot prod; nothing transferred"
+fi
+
+log "mirroring build/species/ -> $PROD_HOST:$PROD_SPECIES"
+rsync "${rsync_common[@]}" --delete "$SPECIES_DIR/" "$PROD_HOST:$PROD_SPECIES/" \
+  || die "prod rsync failed; snapshot $snapshot retained for rollback"
+
+# --- pepmatch-curation: only the indexes, flattened to <taxon>_<k>mers.pepidx.
+# No --partial: a reader mmapping a half-written index is the failure this avoids.
+staging=$(mktemp -d /tmp/pepidx-promote.XXXXXX)
+trap 'rm -rf "$staging"' EXIT
+count=0
+for index in "$SPECIES_DIR"/*/proteome_*mers.pepidx; do
+  [[ -e "$index" ]] || continue
+  taxon=$(basename "$(dirname "$index")")
+  kmer=$(basename "$index" .pepidx); kmer=${kmer#proteome_}
+  ln "$index" "$staging/${taxon}_${kmer}.pepidx" 2>/dev/null \
+    || cp "$index" "$staging/${taxon}_${kmer}.pepidx"
+  count=$(( count + 1 ))
+done
+log "staged $count index files"
+
+log "syncing indexes -> $PEPMATCH_HOST:$PEPMATCH_DIR"
+pepmatch_rsync=(-a --info=progress2 --temp-dir="$PEPMATCH_DIR/.staging")
+(( dry_run )) && pepmatch_rsync+=(-n)
+(( dry_run )) || ssh "${PEPMATCH_SSH[@]}" "$PEPMATCH_HOST" "mkdir -p '$PEPMATCH_DIR/.staging'"
+rsync "${pepmatch_rsync[@]}" -e "$(pepmatch_ssh_cmd)" \
+  "$staging/" "$PEPMATCH_HOST:$PEPMATCH_DIR/" \
+  || die "pepmatch rsync failed; prod is already updated, snapshot $snapshot retained"
+
+# --- verify. rsync -c re-reads and compares content on both sides. Only
+# transfers and deletions count; directory mtimes do not.
+differs() {
+  rsync -acn --itemize-changes "$@" | grep -Eq '^(>|<|c|\*)'
+}
+
+if (( dry_run )); then
+  log "dry-run: skipping checksum verification"
+else
+  log "verifying prod by checksum"
+  differs --delete "$SPECIES_DIR/" "$PROD_HOST:$PROD_SPECIES/" \
+    && die "prod differs after sync; snapshot $snapshot retained"
+  log "verifying pepmatch by checksum"
+  differs -e "$(pepmatch_ssh_cmd)" "$staging/" "$PEPMATCH_HOST:$PEPMATCH_DIR/" \
+    && die "pepmatch differs after sync"
+
+  log "dropping snapshot $snapshot"
+  ssh "${SSH_OPTS[@]}" "$PROD_HOST" "rm -rf '$snapshot'"
+
+  python3 - <<PY
+import json, pathlib, datetime
+path = pathlib.Path('$STATE_DIR/state.json')
+if path.exists():
+  state = json.loads(path.read_text())
+  state['last_sync_completed'] = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+  state['last_sync_release'] = '$release'
+  tmp = path.with_suffix('.json.tmp')
+  tmp.write_text(json.dumps(state, indent=2, sort_keys=True) + '\n')
+  tmp.replace(path)
+PY
+fi
+
+(( dry_run )) && { log "dry-run complete. Nothing was written."; exit 0; }
+log "promoted $release: prod mirrored, $count indexes on pepmatch-curation."

--- a/src/protein/protein_tree/preprocess_3mers.py
+++ b/src/protein/protein_tree/preprocess_3mers.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Build k=3 pepmatch indexes for the species that need them.
+
+Arborist itself only ever uses k=5 (select_proteome.py `_preprocess_proteome`).
+pepmatch-curation additionally serves 3-mer indexes for a fixed short list of
+large, heavily queried species. Rather than teach the build about a second k,
+this runs after a refresh and before a promote, over that list only.
+
+Idempotent: an index newer than its proteome.fasta is left alone unless --force.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+from pepmatch import Preprocessor
+
+# Fixed list, from what pepmatch-curation actually serves today.
+THREE_MER_SPECIES = [
+  9606,   # Homo sapiens
+  10090,  # Mus musculus
+  10116,  # Rattus norvegicus
+  9612,   # Canis lupus
+  9796,   # Equus caballus
+  9823,   # Sus scrofa
+  9913,   # Bos taurus
+  9986,   # Oryctolagus cuniculus
+]
+
+K = 3
+
+
+def index_path(species_path: Path) -> Path:
+  return species_path / f'proteome_{K}mers.pepidx'
+
+
+def needs_build(species_path: Path, force: bool = False) -> bool:
+  """Stale or missing index, given a proteome that actually has content."""
+  fasta = species_path / 'proteome.fasta'
+  if not fasta.exists() or fasta.stat().st_size == 0:
+    return False
+  index = index_path(species_path)
+  if force or not index.exists():
+    return True
+  return index.stat().st_mtime < fasta.stat().st_mtime
+
+
+def build(species_path: Path) -> Path:
+  Preprocessor(
+    proteome=species_path / 'proteome.fasta',
+    preprocessed_files_path=species_path,
+  ).preprocess(k=K)
+  return index_path(species_path)
+
+
+def main(argv=None) -> int:
+  parser = argparse.ArgumentParser(description=__doc__,
+                                   formatter_class=argparse.RawDescriptionHelpFormatter)
+  parser.add_argument('-b', '--build_path', type=Path, required=True)
+  parser.add_argument('-f', '--force', action='store_true',
+                      help='rebuild even when the index is newer than the FASTA')
+  parser.add_argument('-t', '--taxon', type=int, action='append',
+                      help='override the species list (repeatable)')
+  args = parser.parse_args(argv)
+
+  species_ids = args.taxon or THREE_MER_SPECIES
+  built, skipped, missing = 0, 0, []
+
+  for taxon_id in species_ids:
+    species_path = args.build_path / 'species' / str(taxon_id)
+    if not (species_path / 'proteome.fasta').exists():
+      missing.append(taxon_id)
+      print(f'{taxon_id}: no proteome.fasta, skipping', file=sys.stderr)
+      continue
+    if not needs_build(species_path, args.force):
+      skipped += 1
+      print(f'{taxon_id}: {K}-mer index current', file=sys.stderr)
+      continue
+    print(f'{taxon_id}: building {K}-mer index', file=sys.stderr)
+    print(f'{taxon_id}: wrote {build(species_path)}', file=sys.stderr)
+    built += 1
+
+  print(f'{K}-mers: {built} built, {skipped} current, {len(missing)} missing '
+        f'of {len(species_ids)}', file=sys.stderr)
+  # A missing proteome for one of these species is a real problem: they are the
+  # ones prod queries most.
+  return 1 if missing else 0
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -1,0 +1,123 @@
+"""Guards on the only script that writes outside arborist-dev."""
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).parent.parent / 'ops' / 'uniprot-cron' / 'promote-to-prod.sh'
+SOURCE = SCRIPT.read_text()
+
+
+def run(*args):
+  return subprocess.run(['bash', str(SCRIPT), *args], capture_output=True, text=True)
+
+
+def test_refuses_without_an_explicit_mode():
+  """No accidental promotion from a bare invocation."""
+  result = run()
+  assert result.returncode != 0
+  assert '--dry-run' in result.stderr and '--confirm' in result.stderr
+
+
+def test_refuses_off_the_build_host():
+  result = run('--confirm')
+  assert result.returncode != 0
+  assert 'arborist-dev.lji.org' in result.stderr
+
+
+def test_host_gate_precedes_every_remote_write():
+  """The gate must come before ssh, rsync and the snapshot, in source order."""
+  gate = SOURCE.index('BUILD_HOST_FQDN=')
+  for command in ('rsync ', 'ssh "${SSH_OPTS', 'cp -al'):
+    assert gate < SOURCE.index(command), f'{command} appears before the host gate'
+
+
+def test_gate_requires_clean_diff_or_explicit_approval():
+  assert 'last_gate_exit' in SOURCE
+  assert 'APPROVED-$release' in SOURCE
+  # the refusal has to tell you how to approve, or the token is folklore
+  assert 'mv $STATE_DIR/HOLD-$release' in SOURCE
+
+
+def test_prod_is_a_full_mirror_not_a_delta():
+  """Dev and prod must match exactly; syncing only changed species would drift."""
+  prod_sync = next(line for line in SOURCE.splitlines()
+                   if 'PROD_HOST:$PROD_SPECIES/' in line and line.strip().startswith('rsync'))
+  assert '--delete' in prod_sync
+  assert '$SPECIES_DIR/' in prod_sync
+
+
+def test_snapshot_is_hardlinked_and_dropped_on_success():
+  """A copy would need 83G of the 104G free on prod; hardlinks need none."""
+  assert 'cp -al' in SOURCE
+  assert 'cp -a ' not in SOURCE
+  assert re.search(r'rm -rf .\$snapshot', SOURCE)
+  # dropped only after both verifications
+  assert SOURCE.index('verifying pepmatch') < SOURCE.index('dropping snapshot')
+
+
+def test_pepmatch_sync_cannot_leave_a_torn_index():
+  """A reader mmapping a half-written .pepidx is the failure mode to avoid."""
+  pepmatch_block = SOURCE[SOURCE.index('pepmatch_rsync=('):SOURCE.index('# --- verify')]
+  assert '--temp-dir=' in pepmatch_block
+  assert '--inplace' not in SOURCE
+  assert '--partial ' not in SOURCE  # --partial-dir on the prod tree is fine
+
+
+def test_pepmatch_uses_the_existing_key():
+  """Reuse dmarrama's key rather than minting a second credential."""
+  assert 'PEPMATCH_KEY=/home/dmarrama/.ssh/pepmatch_curation_rsa' in SOURCE
+  assert 'IdentitiesOnly=yes' in SOURCE
+  assert 'BatchMode=yes' in SOURCE
+
+
+def test_indexes_are_flattened_for_pepmatch():
+  """Destination is one flat directory: <taxon>_<k>mers.pepidx."""
+  assert '${taxon}_${kmer}.pepidx' in SOURCE
+  assert 'proteome_*mers.pepidx' in SOURCE
+
+
+def test_failure_after_prod_sync_keeps_the_rollback_point():
+  for message in ('prod rsync failed', 'pepmatch rsync failed', 'prod differs after sync'):
+    line = next(l for l in SOURCE.splitlines() if message in l)
+    assert 'snapshot' in line, f'{message} does not mention the rollback point'
+
+
+@pytest.mark.parametrize('taxon', [9606, 10090, 10116, 9612, 9796, 9823, 9913, 9986])
+def test_three_mer_species_list(taxon):
+  from protein_tree.preprocess_3mers import THREE_MER_SPECIES
+  assert taxon in THREE_MER_SPECIES
+
+
+def test_three_mer_list_is_exactly_the_eight_served():
+  from protein_tree.preprocess_3mers import THREE_MER_SPECIES, K
+  assert len(THREE_MER_SPECIES) == 8
+  assert K == 3
+
+
+def test_three_mer_build_skips_current_indexes(tmp_path):
+  from protein_tree.preprocess_3mers import needs_build, index_path
+  species = tmp_path / '9606'
+  species.mkdir()
+  fasta = species / 'proteome.fasta'
+  fasta.write_text('>a\nMK\n')
+
+  assert needs_build(species) is True
+
+  index = index_path(species)
+  index.write_text('x')
+  import os
+  os.utime(index, (fasta.stat().st_mtime + 10, fasta.stat().st_mtime + 10))
+  assert needs_build(species) is False
+  assert needs_build(species, force=True) is True
+
+
+def test_three_mer_build_skips_empty_proteomes(tmp_path):
+  """An EMPTY species has nothing to index; that is not an error."""
+  from protein_tree.preprocess_3mers import needs_build
+  species = tmp_path / '1234'
+  species.mkdir()
+  (species / 'proteome.fasta').write_text('')
+  assert needs_build(species) is False


### PR DESCRIPTION
The last build phase. Dev pushes to both consumers; nothing is automatic.

| Destination | Payload |
|---|---|
| `arborist` (prod) | all of `build/species/` — full mirror, `--delete`, ~83 G |
| `dmarrama@pepmatch-curation` | every `.pepidx` flattened to `<taxon>_<k>mers.pepidx` in `/media/data/pepmatch/proteomes/` — ~1,710 five-mers + 8 three-mers |

**Full mirror, not a delta.** Prod must match dev exactly; syncing only changed species would let the two drift.

## Rollback point is hardlinked

Prod has 104 G free against an 83 G tree, so `cp -a` would nearly fill the disk. `cp -al` costs directory entries and seconds, and since rsync replaces files by rename, the snapshot keeps the old inodes intact. Deleted on success; retained on any failure after it's taken, and every failure message says so.

## k=3

Arborist only ever builds k=5. `preprocess_3mers.py` builds 3-mers for the eight species pepmatch-curation serves them for — 9606, 10090, 10116, 9612, 9796, 9823, 9913, 9986 — reusing pepmatch's own `Preprocessor`. Idempotent against FASTA mtime.

## Gate

Refuses unless `last_gate_exit` is 0 or `APPROVED-<release>` exists, and the refusal prints the exact `mv` that approves it — otherwise the token protocol is folklore.

## ssh

`BatchMode=yes` throughout, so a missing key fails in seconds instead of hanging. Prod uses root's key. pepmatch-curation uses the **existing** `/home/dmarrama/.ssh/pepmatch_curation_rsa` rather than minting a second credential.

**Open:** root@arborist-dev couldn't authenticate to pepmatch-curation in testing. The key exists but may not be authorized for root. The script fails fast with a named error; needs one verification on the box before a real promote.

## Tests

22 new, 132 passing. Host gate precedes every remote write in source order; prod sync is a mirror not a delta; no `--inplace` or bare `--partial` anywhere near the live index dir; snapshot is hardlinked and dropped only after both checksum passes; every post-sync failure message names the rollback point.

The k=3 builder was smoke-tested for real — built an index from a hand-made FASTA, then correctly skipped it as current. The promote script can't run off arborist-dev; its gates were verified by watching it refuse.